### PR TITLE
Change to intersect branding in remote theme

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@
 # lc: Library Carpentry
 # cp: Carpentries (to use for instructor traning for instance)
 # incubator: Carpentries Incubator
-carpentry: "incubator"
+carpentry: "intersect"
 
 # Overall title for pages.
 title: "Packaging"
@@ -34,6 +34,7 @@ repository: INTERSECT-training/packaging
 email: ""
 
 # Sites.
+intersect_site: "https://intersect-training.org/"
 coc: "https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html"
 amy_site: "https://amy.carpentries.org/"
 carpentries_github: "https://github.com/carpentries"


### PR DESCRIPTION
This PR updates the branding for INTERSECT. There are some more updates to go (e.g. contributing and code of conduct). So for now it's just a draft until these are fixed. 