### PR TITLE
feat: docs (a bit advanced)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,12 @@ repos:
   - id: trailing-whitespace
     files: ^(_episodes|code|README.md|setup.md)
 
+- repo: https://github.com/asottile/blacken-docs
+  rev: "1.13.0"
+  hooks:
+    - id: blacken-docs
+      additional_dependencies: [black==23.3.0]
+
 - repo: https://github.com/codespell-project/codespell
   rev: 'v2.1.0'
   hooks:

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Please see the current list of [issues][FIXME] for ideas for contributing to thi
 repository. For making your contribution, we use the GitHub flow, which is
 nicely explained in the chapter [Contributing to a Project](http://git-scm.com/book/en/v2/GitHub-Contributing-to-a-Project) in Pro Git
 by Scott Chacon.
-Look for the tag ![good_first_issue](https://img.shields.io/badge/-good%20first%20issue-gold.svg). 
-This indicates that the maintainers will welcome a pull request fixing this issue.  
+Look for the tag ![good_first_issue](https://img.shields.io/badge/-good%20first%20issue-gold.svg).
+This indicates that the maintainers will welcome a pull request fixing this issue.
 
 If you contribute to this lesson and would like to acknowledge specific funding support, please add it to the Funding section of the README below.
 

--- a/_episodes/01-environment.md
+++ b/_episodes/01-environment.md
@@ -192,6 +192,7 @@ this file in a local directory:
 ```python
 # test_nox.py
 
+
 def test_runs():
     assert True
 ```
@@ -203,6 +204,7 @@ minimal session that runs pytest:
 ```python
 # noxfile.py
 import nox
+
 
 @nox.session()
 def tests(session):
@@ -229,6 +231,7 @@ Let's expand this a little:
 ```python
 # noxfile.py
 import nox
+
 
 @nox.session()
 def tests(session: nox.Session) -> None:

--- a/_episodes/02-jupyter-to-package.md
+++ b/_episodes/02-jupyter-to-package.md
@@ -29,6 +29,7 @@ Then, in a Python shell or Jupyter Notebook, declare the function:
 ```python
 import numpy as np
 
+
 def rescale(input_array):
     """Rescales an array from 0 to 1.
 
@@ -44,7 +45,7 @@ def rescale(input_array):
 and call the function with:
 
 ```python
->>> rescale(np.linspace(0, 100, 5))
+rescale(np.linspace(0, 100, 5))
 ```
 
 which provides the output:
@@ -147,9 +148,10 @@ The `-e` flag tells `pip` to install in editable mode, meaning that you can cont
 Then, in a Python shell or Jupyter Notebook, import your package and call the (single) function:
 
 ```python
->>> import numpy as np
->>> from package.rescale import rescale
->>> rescale(np.linspace(0, 100, 5))
+import numpy as np
+from package.rescale import rescale
+
+rescale(np.linspace(0, 100, 5))
 ```
 
 ```
@@ -175,11 +177,12 @@ In this file, we need to import the package, and check that a call to the `resca
 import numpy as np
 from package.rescale import rescale
 
+
 def test_rescale():
     np.testing.assert_allclose(
         rescale(np.linspace(0, 100, 5)),
-        np.array([0., 0.25, 0.5, 0.75, 1.0 ]),
-        )
+        np.array([0.0, 0.25, 0.5, 0.75, 1.0]),
+    )
 ```
 
 Next, take the `noxfile.py` you created in an earlier episode, and modify it to
@@ -194,11 +197,12 @@ with:
 # contents of noxfile.py
 import nox
 
+
 @nox.session
 def tests(session):
-    session.install('numpy', 'pytest')
-    session.install('.')
-    session.run('pytest')
+    session.install("numpy", "pytest")
+    session.install(".")
+    session.run("pytest")
 ```
 
 Now, with the added test file and `noxfile.py`, your package's directory structure should look like:

--- a/_episodes/03-other-files.md
+++ b/_episodes/03-other-files.md
@@ -207,6 +207,7 @@ the array holds the same number repeated). For example:
 ```python
 import numpy as np
 from package.rescale import rescale
+
 a = 2 * np.ones(5)
 rescale(a)
 ```
@@ -244,6 +245,7 @@ Now, when we call rescale (no need to reinstall or upgrade the package, since we
 ```python
 import numpy as np
 from package.rescale import rescale
+
 a = 2 * np.ones(5)
 rescale(a)
 ```

--- a/_episodes/04-metadata.md
+++ b/_episodes/04-metadata.md
@@ -57,7 +57,7 @@ readme = "README.rst"
 
 This is a list of authors (or maintainers) as (usually inline) tables. A TOML table is very much like a Python dict.
 
-```python
+```toml
 authors = [
     {name="Me Myself", email="email@mail.com"},
     {name="You Yourself", email="email2@mail.com"},
@@ -121,11 +121,20 @@ classifiers = [
 
 ### License (special mention)
 
-There also is a license field, but that was rather inadequate; it didn't support multiple licenses, for example. Currently, it's best to indicate the license with a Trove Classifier, and make sure your file is called `LICENSE*` so build backends pick it up and include it in SDist and wheels. There's work on standardizing an update to the format in the future. You can manually specify a license file if you want:
+There also is a license field, but that was rather inadequate; it didn't support
+multiple licenses, for example. Currently, it's best to indicate the license
+with a Trove Classifier, and make sure your file is called `LICENSE*` so build
+backends pick it up and include it in SDist and wheels. There's work on
+standardizing an update to the format in the future. You can manually specify a
+license file if you want:
 
 ```toml
 license = {file = "LICENSE"}
 ```
+
+However, some backends (like flit-core) ignore this field entirely. The
+canonical location for a standard license since the early 2000's has been trove
+classifiers.
 
 > ## Verify file contents
 > Always verify the contents of your SDist and Wheel(s) manually to make sure the license file is included.
@@ -234,7 +243,6 @@ authors = [
 ]
 description = "A small example package"
 readme = "README.md"
-license = { file="LICENSE" }
 requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -246,6 +254,19 @@ classifiers = [
 "Homepage" = "https://github.com/pypa/sampleproject"
 "Bug Tracker" = "https://github.com/pypa/sampleproject/issues"
 ````
+
+> ## Add metadata and check it.
+> Take your existing package and add more metadata to it. Install it, then use
+> `pip show -v <package>` to see the metadata. You can also look inside the wheel
+> or SDist to see the metadata.
+>
+> > ## Solution
+> > ```bash
+> > pip install -e .
+> > pip show -v <package-name>
+> > ```
+> {:.solution}
+{:.challenge}
 
 
 {% include links.md %}

--- a/_episodes/05-versioning.md
+++ b/_episodes/05-versioning.md
@@ -285,4 +285,9 @@ ref-names: $Format:%D$
 Now `git archive`'s output (like the tarballs GitHub provides) will also include
 the version information (for recent versions of git)!
 
+> ## Add a versioning system
+> Add one of the two single-version systems listed above to your package.
+>
+{:.challenge}
+
 {% include links.md %}

--- a/_episodes/06-documentation.md
+++ b/_episodes/06-documentation.md
@@ -3,12 +3,205 @@ title: "Documentation"
 teaching: 0
 exercises: 0
 questions:
-- "Key question (FIXME)"
+- "How do I document my project?"
 objectives:
-- "First learning objective. (FIXME)"
+- "Learn how to set up documentation"
 keypoints:
-- "First key point. Brief Answer to questions. (FIXME)"
+- "Sphinx is used for documentation"
 ---
-FIXME
+
+Documentation used to require learning RestructureText (sometimes referred to as
+ReST / RST), but today we have great choices for documentation in markdown, the
+same format used by GitHub, Wikipedia, and others.  You should select one of the
+two major documentation toolchains, sphinx or mkdocs. We will select the older
+Sphinx for this tutorial, and use the modern MyST plugin to get markdown
+support.
+
+## Basic template
+
+We'll start with the built-in template. Start by creating a `docs/` directory
+within your project (i.e. next to `src/`).
+
+You _could_ use sphinx-quickstart to set up a basic template if you'd like.
+
+```bash
+pipx run --spec sphinx sphinx-quickstart --no-makefile --no-batchfile --ext-autodoc --ext-intersphinx --extensions myst_parser --suffix .md docs
+```
+
+But this will put Restructured Text into the `index.md` file, and doesn't really generate that much for you. You can instead add the `docs/conf.py` file yourself:
+
+```python
+import importlib.metadata
+
+project = "<package>"
+copyright = "2023, Your Name"
+author = "Your Name"
+version = release = importlib.metadata.version("project-name")
+
+extensions = [
+    "myst_parser",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
+    "sphinx_copybutton",
+]
+
+exclude_patterns = [
+    "_build",
+    "Thumbs.db",
+    ".DS_Store",
+    "**.ipynb_checkpoints",
+    ".env",
+    ".venv",
+]
+
+source_suffix = [".md", ".rst"]
+
+html_theme = "furo"
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+}
+```
+
+Compared to what would have been generated, we are using `furo` for the theme
+(used by the PyPA and related to the theme being worked on for CPython 3.13's
+docs). We also are including the version number, both possible file extensions,
+some options for myst, and better exclude patterns. And less extra comments and
+unnecessary stuff.
+
+And add (a correct) `docs/index.md` yourself:
+
+````md
+# repo-review
+
+```{toctree}
+:maxdepth: 2
+:hidden:
+
+```
+
+## Indices and tables
+
+* {ref}`genindex`
+* {ref}`modindex`
+* {ref}`search`
+````
+
+As you add new pages, you will list them in the toctree above.
+
+Even if you used it, the generation won't add a `docs` extra (or
+`docs/requirements.txt`, if you prefer not making a public extra) for you, so
+you'll need to add this yourself to `pyproject.toml`:
+
+```toml
+[project.optional-dependencies]
+docs = [
+  "furo",
+  "myst_parser >=0.13",
+  "sphinx >=4.0",
+  "sphinx-copybutton",
+]
+
+```
+
+And add a session to your `noxfile.py` to generate docs:
+
+```python
+@nox.session(reuse_venv=True)
+def docs(session: nox.Session) -> None:
+    """
+    Build the docs. Pass "--serve" to serve.
+    """
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--serve", action="store_true", help="Serve after building")
+    args, posargs = parser.parse_known_args(session.posargs)
+
+    session.install(".[docs]")
+    session.chdir("docs")
+
+    session.run(
+        "sphinx-build",
+        "-b",
+        "html",
+        ".",
+        f"_build/html",
+        *posargs,
+    )
+
+    if args.serve:
+        session.log("Launching docs at http://localhost:8000/ - use Ctrl-C to quit")
+        session.run("python", "-m", "http.server", "8000", "-d", "_build/html")
+```
+
+And you now have working docs that you can generate and view cross platform with `nox -s docs -- --serve`!
+
+If you want to use https://readthedocs.org to build your docs, you'll also want the following `.readthedocs.yml`:
+
+```yaml
+version: 2
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
+sphinx:
+  configuration: docs/conf.py
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+```
+
+## API docs
+
+To build API docs, you need to add the following nox job:
+
+```python
+@nox.session
+def build_api_docs(session: nox.Session) -> None:
+    """
+    Build (regenerate) API docs.
+    """
+    session.install("sphinx")
+    session.chdir("docs")
+    session.run(
+        "sphinx-apidoc",
+        "-o",
+        "api/",
+        "--module-first",
+        "--no-toc",
+        "--force",
+        "../src/<package>",
+    )
+```
+
+And you'll need this added to your `docs/index.md`:
+
+````md
+```{toctree}
+:maxdepth: 2
+:hidden:
+:caption: API
+
+api/repo_review
+```
+````
+
+Note that your docstrings are still parsed as Restructured Text.
+
+## Readme in docs
+
+If you want to include your readme in your docs, you can add something like this:
+
+````md
+```{include} ../README.md
+:start-after: <!-- SPHINX-START -->
+```
+````
+
+And you use `<!-- SPHINX-START ->>` to mark where you want your docs part of
+your readme to start (generally after the title and badges).
 
 {% include links.md %}


### PR DESCRIPTION
Probably will basically swap with https://scientific-python-cookie.readthedocs.io/en/latest/guides/writing-docs eventually (and move that page to tutorials).
