### PR TITLE
ci: Add pre-commit hooks

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,5 +9,6 @@
         "charliermarsh.ruff"
       ]
     }
-  }
+  },
+  "postCreateCommand": "pip install --user --upgrade pre-commit && pre-commit run && pre-commit install"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,8 @@
       "extensions": [
         "ms-python.python",
         "donjayamanne.python-environment-manager",
-        "charliermarsh.ruff"
+        "charliermarsh.ruff",
+        "github.vscode-github-actions"
       ]
     }
   },

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,14 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+    - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
+  rev: v4.6.0
   hooks:
   - id: check-added-large-files
   - id: check-case-conflict
@@ -14,13 +14,13 @@ repos:
     files: ^(_episodes|code|README.md|setup.md)
 
 - repo: https://github.com/asottile/blacken-docs
-  rev: "1.13.0"
+  rev: "1.16.0"
   hooks:
     - id: blacken-docs
       additional_dependencies: [black==23.3.0]
 
 - repo: https://github.com/codespell-project/codespell
-  rev: 'v2.1.0'
+  rev: 'v2.3.0'
   hooks:
   - id: codespell
     types_or: [markdown]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,3 @@
-ci:
-    autoupdate_schedule: monthly
-
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.3.0

--- a/_episodes/01-environment.md
+++ b/_episodes/01-environment.md
@@ -221,7 +221,7 @@ changeable via keyword arguments to session.
 
 The session function will be given a `nox.Session` object that has various
 useful methods. `.install` will install things with pip, and `.run` will run a
-command in a sesson. The `.run` command will print a warning if you use an
+command in a session. The `.run` command will print a warning if you use an
 executable outside the virtual environment unless `external=True` is passed.
 Errors will exit the session.
 

--- a/_episodes/05-versioning.md
+++ b/_episodes/05-versioning.md
@@ -160,7 +160,7 @@ Linux distros, for example), then you should try to support a few past releases
 of dependencies, and ideally run your tests at least once with the minimum
 versions of your dependencies. You can do this with a `constraints.txt` file,
 which specifies pins on the minimum versions of all your dependencies, and then
-add `-c constrainsts.txt` when pip installing.
+add `-c constraints.txt` when pip installing.
 
 #### Maximums:
 

--- a/_episodes/08-continuous-integration.md
+++ b/_episodes/08-continuous-integration.md
@@ -91,7 +91,7 @@ example:
 
 
 would produce three jobs, with names `Job 1`, `Job 2`, and `Job 3`. Elsewhere,
-if you refer to the `exmaple` job, it will implicitly refer to all three.
+if you refer to the `example` job, it will implicitly refer to all three.
 
 This is commonly used to set Python and operating system versions:
 


### PR DESCRIPTION
New changes:
- Add pre-commit hooks to CI using GitHub actions
- Add pre-commit hooks to devcontainer
- Updates pre-commit hook versions
- Drive-by fixes of some typos which cause errors in the pre-commit hooks

Related issues:
- resolves #5 
- resolves #25 