### PR TITLE
chore: add up-to-date citation file for version 2023

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -1,4 +1,0 @@
-Please cite as:
-
-Jeffrey C. Carver and Ian A. Cosden (ed.): "INTERSECT: Lesson Example."  Version
-2023.06, June 2023, https://github.com/INTERSECT-training/intersect-module-template

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,17 +1,5 @@
 cff-version: 1.2.0
 message: "Please cite as:"
-
-authors:
-  - family-names: "Schreiner"
-    given-names: "Henry"
-    orcid: "https://orcid.org/0000-0002-7833-783X"
-  - family-names: "Niemeyer"
-    given-names: "Kyle"
-    orcid: "https://orcid.org/0000-0003-4425-7097"
-title: "INTERSECT: Packaging"
-url: "https://github.com/INTERSECT-training/software-licensing"
-version: 2023.06
-date-released: 2023-07-10
 preferred-citation:
   type: article
   authors:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,12 +1,14 @@
 cff-version: 1.2.0
 message: "Please cite as:"
+type: article
 authors:
-  - family-names: Schreiner
-    given-names: Henry
-    orcid: https://orcid.org/0000-0002-7833-783X
-  - family-names: Niemeyer
-    given-names: Kyle
-    orcid: https://orcid.org/0000-0003-4425-7097
+  - family-names: "Schreiner"
+    given-names: "Henry"
+    orcid: "https://orcid.org/0000-0002-7833-783X"
+  - family-names: "Niemeyer"
+    given-names: "Kyle"
+    orcid: "https://orcid.org/0000-0003-4425-7097"
 title: "INTERSECT: Packaging"
+url: "https://github.com/INTERSECT-training/software-licensing"
 version: 2023.06
 date-released: 2023-07-10

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,12 @@
+cff-version: 1.2.0
+message: "Please cite as:"
+authors:
+  - family-names: Schreiner
+    given-names: Henry
+    orcid: https://orcid.org/0000-0002-7833-783X
+  - family-names: Niemeyer
+    given-names: Kyle
+    orcid: https://orcid.org/0000-0003-4425-7097
+title: "INTERSECT: Packaging"
+version: 2023.06
+date-released: 2023-07-10

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,15 +1,13 @@
 cff-version: 1.2.0
 message: "Please cite as:"
-preferred-citation:
-  type: article
-  authors:
-    - family-names: "Schreiner"
-      given-names: "Henry"
-      orcid: "https://orcid.org/0000-0002-7833-783X"
-    - family-names: "Niemeyer"
-      given-names: "Kyle"
-      orcid: "https://orcid.org/0000-0003-4425-7097"
-  title: "INTERSECT: Packaging"
-  url: "https://github.com/INTERSECT-training/software-licensing"
-  year: 2023
-  month: 07
+type: dataset
+authors:
+  - family-names: "Schreiner"
+    given-names: "Henry"
+    orcid: "https://orcid.org/0000-0002-7833-783X"
+  - family-names: "Niemeyer"
+    given-names: "Kyle"
+    orcid: "https://orcid.org/0000-0003-4425-7097"
+title: "INTERSECT: Packaging"
+url: "https://github.com/INTERSECT-training/software-licensing"
+date-released: "2023-07-10"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 message: "Please cite as:"
-type: article
+
 authors:
   - family-names: "Schreiner"
     given-names: "Henry"
@@ -12,3 +12,16 @@ title: "INTERSECT: Packaging"
 url: "https://github.com/INTERSECT-training/software-licensing"
 version: 2023.06
 date-released: 2023-07-10
+preferred-citation:
+  type: article
+  authors:
+    - family-names: "Schreiner"
+      given-names: "Henry"
+      orcid: "https://orcid.org/0000-0002-7833-783X"
+    - family-names: "Niemeyer"
+      given-names: "Kyle"
+      orcid: "https://orcid.org/0000-0003-4425-7097"
+  title: "INTERSECT: Packaging"
+  url: "https://github.com/INTERSECT-training/software-licensing"
+  year: 2023
+  month: 07

--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ If you would like to serve as a maintainer please [contact us](https://intersect
 
 To cite this lesson, please consult with [CITATION.cff](CITATION.cff).
 
-[lesson-example]: https://carpentries.github.io/lesson-example
-
 ## Funding
 
 The INTERSECT project is supported by NSF awards [2017424](https://www.nsf.gov/awardsearch/showAward?AWD_ID=2017424) and [2017259](https://www.nsf.gov/awardsearch/showAward?AWD_ID=2017259).

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you would like to serve as a maintainer please [contact us](https://intersect
 
 ## Citation
 
-To cite this lesson, please consult with [CITATION](CITATION).
+To cite this lesson, please consult with [CITATION.cff](CITATION.cff).
 
 [lesson-example]: https://carpentries.github.io/lesson-example
 


### PR DESCRIPTION
- Add a new CITATION.cff file.
- Delete old CITATION file.

We use the standard in the template from Carpentries – flagging this as a dataset. https://github.com/carpentries/workbench-template-md/blob/main/CITATION.cff

- resolves #28 