### PR TITLE
bug: add missing # to fix rendering of solution

### DIFF
--- a/_episodes/09-publishing-citations.md
+++ b/_episodes/09-publishing-citations.md
@@ -77,7 +77,7 @@ you have more control over who can publish in GitHub.
 > Given what you've learned about `nox` and `build`, write a session that builds
 > packages for you.
 >
-> > # Solution
+> > ## Solution
 > > ```python
 > > import nox
 > >


### PR DESCRIPTION
The single `#` in the header makes the solution unselectable. Checked – there don't appear to be any other like this. 
- resolves #43