### PR TITLE
feat: add setup instructions

### DIFF
--- a/index.md
+++ b/index.md
@@ -34,7 +34,6 @@ that by showing you a clean, modern way to write and work with Python packages.
 > ## Prerequisites
 >
 > * Basic Python
-> * Light familiarity with pytest may be helpful
 {: .prereq}
 
 {% include links.md %}

--- a/setup.md
+++ b/setup.md
@@ -6,6 +6,7 @@ title: Setup
 > You will need accounts on:
 > - [https://github.com/](https://github.com/)
 > - [https://test.pypi.org/](https://test.pypi.org/)
+> - [https://zenodo.org/](https://zenodo.org/)
 >
 > These instructions serve to help set up:
 > - an editor,
@@ -26,6 +27,8 @@ If you don't already have them, sign up for accounts on:
 
 - [https://github.com/join](https://github.com/join) (required for the part on "continuous integration", optional for setting up a development environment)
 - [https://test.pypi.org/account/register/](https://test.pypi.org/account/register/) (required for the part on publishing)
+- [https://zenodo.org/signup/](https://zenodo.org/signup/) (optional for the part on citation)
+
 
 ## Development Environment
 

--- a/setup.md
+++ b/setup.md
@@ -29,8 +29,8 @@ If you don't already have them, sign up for accounts on:
 
 ## Development Environment
 
-> ## If this is your first time, use `Cloud Setup`
-> If you have not installed and used these tools before, then in the interests of time for the lesson, please use the **Cloud Setup**. After the session you can repeat the setup using the Local Setup instructions.
+> ## If this is your first time, use the `Cloud` instructions
+> If you have not installed and used these tools before, then in the interests of time for the lesson, please use the **Cloud** setup instructions. After the session you can repeat the setup using the Local setup instructions.
 >
 > Support will be available for the rest of the week if you have trouble with setting up these tools locally!
 {:.caution}
@@ -73,7 +73,7 @@ Python 3.12.3
 
 If this command returns something like `command not found: python3` then install python using the instructions on[https://docs.pytest.org/en/stable/getting-started.html](https://docs.pytest.org/en/stable/getting-started.html).
 
-### Git & GitHub
+#### Git & GitHub
 
 You will need a GitHub account and an installation of Git.
 

--- a/setup.md
+++ b/setup.md
@@ -19,11 +19,6 @@ title: Setup
 {:.objectives}
 
 
-> ## If this is your first time, use `Cloud Setup`
-> If you have not installed and used these tools before, then in the interests of time for the lesson, please use the **Cloud Setup**. After the session you can repeat the setup using the Local Setup instructions.
->
-> Support will be available for the rest of the week if you have trouble with setting up these tools locally!
-{:.caution}
 
 ## User Accounts
 
@@ -33,6 +28,12 @@ If you don't already have them, sign up for accounts on:
 - [https://test.pypi.org/account/register/](https://test.pypi.org/account/register/) (required for the part on publishing)
 
 ## Development Environment
+
+> ## If this is your first time, use `Cloud Setup`
+> If you have not installed and used these tools before, then in the interests of time for the lesson, please use the **Cloud Setup**. After the session you can repeat the setup using the Local Setup instructions.
+>
+> Support will be available for the rest of the week if you have trouble with setting up these tools locally!
+{:.caution}
 
 ### Cloud
 

--- a/setup.md
+++ b/setup.md
@@ -3,15 +3,19 @@ title: Setup
 ---
 
 > ## Objectives
+> You will need accounts on:
+> - [https://github.com/](https://github.com/)
+> - [https://test.pypi.org/](https://test.pypi.org/)
+>
 > These instructions serve to help set up:
 > - an editor,
 > - a shell,
 > - python,
 > - git,
-> - GitHub, and
-> - an empty repository,
+> - an empty repository
 >
 > either in the cloud (fast) or on a local computer (slow the first time).
+>
 {:.objectives}
 
 
@@ -21,32 +25,40 @@ title: Setup
 > Support will be available for the rest of the week if you have trouble with setting up these tools locally!
 {:.caution}
 
-## Cloud Setup
+## User Accounts
+
+If you don't already have them, sign up for accounts on:
+
+- [https://github.com/join](https://github.com/join) (required for the part on "continuous integration", optional for setting up a development environment)
+- [https://test.pypi.org/account/register/](https://test.pypi.org/account/register/) (required for the part on publishing)
+
+## Development Environment
+
+### Cloud
 
 You can get all the prerequisites for this lesson by using a GitHub Codespace.
 
-- You will need a GitHub account from [https://github.com/join](https://github.com/join).
 - Create a new repository by going to [https://github.com/new](https://github.com/new).
   - Ensure that the owner is you.
   - Initialize the repository with a README file by clicking the tickmark next to `Add a README file`.
 - After the repository is created, click on the `< > Code` button, click the `Codespaces` tab, and click `Create codespace on main`. This will create an editor with a shell, `python` and `git` pre-configured for you.
 
-## Local Setup
+### Local
 
 If you want to run this example on your own computer, you will need to install the parts independently.
 
-### Editor
+#### Editor
 
 We recommend using the text editor VSCode from [https://code.visualstudio.com/](https://code.visualstudio.com/) for this lesson. We won't be using any of its special features, so if you prefer a different editor, please use that.
 
-### Shell
+#### Shell
 
 This lesson uses shell commands which you can run in a terminal emulator. Depending on the operating system you use, you have different options.
 - Linux – you can use any terminal emulator. Common options are `GNOME Terminal` and `Konsole (KDE)`.
 - macOS – you can use any terminal emulator. Common options are: `Terminal.app`, `iTerm2`
 - Windows – we recommend using the Windows Subsystem for Linux to install Linux (https://learn.microsoft.com/en-us/windows/wsl/install). You could also use Powershell, but some commands will be different and others unavailable.
 
-### Python
+#### Python
 
 You will need to have Python installed for this lesson.
 
@@ -68,7 +80,7 @@ If you don't already have a GitHub account you can sign up at [https://github.co
 
 For beginners, we recommend using GitHub desktop when working with GitHub – installation instructions at [https://desktop.github.com/](https://desktop.github.com/).
 
-### Empty repository
+#### Empty repository
 
 Create a new repository using GitHub desktop.
 - Open GitHub Desktop

--- a/setup.md
+++ b/setup.md
@@ -74,7 +74,12 @@ Python 3.12.3
 ```
 {:code}
 
-If this command returns something like `command not found: python3` then install python using the instructions on[https://wiki.python.org/moin/BeginnersGuide/Download](https://wiki.python.org/moin/BeginnersGuide/Download).
+If this command returns something like `command not found: python3` then you can install python using:
+- The instructions on [https://wiki.python.org/moin/BeginnersGuide/Download](https://wiki.python.org/moin/BeginnersGuide/Download), or
+- Tools like
+  [`asdf`](https://asdf-vm.com/),
+  [`mise`](https://mise.jdx.dev/lang/python), or
+  [`pyenv`](https://github.com/pyenv/pyenv).
 
 #### Git & GitHub
 

--- a/setup.md
+++ b/setup.md
@@ -74,12 +74,15 @@ Python 3.12.3
 ```
 {:code}
 
-If this command returns something like `command not found: python3` then you can install python using:
-- The instructions on [https://wiki.python.org/moin/BeginnersGuide/Download](https://wiki.python.org/moin/BeginnersGuide/Download), or
-- Tools like
-  [`asdf`](https://asdf-vm.com/),
-  [`mise`](https://mise.jdx.dev/lang/python), or
-  [`pyenv`](https://github.com/pyenv/pyenv).
+If this command returns something like `command not found: python3` then you can install python using
+the instructions on [https://wiki.python.org/moin/BeginnersGuide/Download](https://wiki.python.org/moin/BeginnersGuide/Download).
+
+Often, developers will need to manage multiple projects which might all use several different python versions.
+This is sometimes tricky, and there are specialized tools which can help, like:
+- [`asdf`](https://asdf-vm.com/),
+- [`mise`](https://mise.jdx.dev/lang/python), or
+- [`pyenv`](https://github.com/pyenv/pyenv).
+
 
 #### Git & GitHub
 

--- a/setup.md
+++ b/setup.md
@@ -1,7 +1,85 @@
 ---
 title: Setup
 ---
-FIXME
 
+> ## Objectives
+> These instructions serve to help set up:
+> - an editor,
+> - a shell,
+> - python,
+> - git,
+> - GitHub, and
+> - an empty repository,
+>
+> either in the cloud (fast) or on a local computer (slow the first time).
+{:.objectives}
+
+
+> ## If this is your first time, use `Cloud Setup`
+> If you have not installed and used these tools before, then in the interests of time for the lesson, please use the **Cloud Setup**. After the session you can repeat the setup using the Local Setup instructions.
+>
+> Support will be available for the rest of the week if you have trouble with setting up these tools locally!
+{:.caution}
+
+## Cloud Setup
+
+You can get all the prerequisites for this lesson by using a GitHub Codespace.
+
+- You will need a GitHub account from [https://github.com/join](https://github.com/join).
+- Create a new repository by going to [https://github.com/new](https://github.com/new).
+  - Ensure that the owner is you.
+  - Initialize the repository with a README file by clicking the tickmark next to `Add a README file`.
+- After the repository is created, click on the `< > Code` button, click the `Codespaces` tab, and click `Create codespace on main`. This will create an editor with a shell, `python` and `git` pre-configured for you.
+
+## Local Setup
+
+If you want to run this example on your own computer, you will need to install the parts independently.
+
+### Editor
+
+We recommend using the text editor VSCode from [https://code.visualstudio.com/](https://code.visualstudio.com/) for this lesson. We won't be using any of its special features, so if you prefer a different editor, please use that.
+
+### Shell
+
+This lesson uses shell commands which you can run in a terminal emulator. Depending on the operating system you use, you have different options.
+- Linux – you can use any terminal emulator. Common options are `GNOME Terminal` and `Konsole (KDE)`.
+- macOS – you can use any terminal emulator. Common options are: `Terminal.app`, `iTerm2`
+- Windows – we recommend using the Windows Subsystem for Linux to install Linux (https://learn.microsoft.com/en-us/windows/wsl/install). You could also use Powershell, but some commands will be different and others unavailable.
+
+### Python
+
+You will need to have Python installed for this lesson.
+
+To check if python is available in your shell, call `python3 --version`. You should see some output like:
+
+```bash
+% python3 --version
+Python 3.12.3
+```
+{:code}
+
+If this command returns something like `command not found: python3` then install python using the instructions on[https://docs.pytest.org/en/stable/getting-started.html](https://docs.pytest.org/en/stable/getting-started.html).
+
+### Git & GitHub
+
+You will need a GitHub account and an installation of Git.
+
+If you don't already have a GitHub account you can sign up at [https://github.com/join](https://github.com/join).
+
+For beginners, we recommend using GitHub desktop when working with GitHub – installation instructions at [https://desktop.github.com/](https://desktop.github.com/).
+
+### Empty repository
+
+Create a new repository using GitHub desktop.
+- Open GitHub Desktop
+- Select File > New Repository
+- Specify the repository data:
+  - Name: package-example (use dashes `-`, don't use underscores `_` for this name)
+  - Local Path: pick somewhere which _isn't_ synced to a cloud provider like DropBox, OneDrive or iCloud – they can interfere with `git`.
+  - Initialize the repository with a README.
+  - Leave the .gitignore and License both as "None".
+- Click `Create repository`
+- Click `Publish repository` to make it available on GitHub.
+- Click `Open in Visual Studio Code` _or_ open Visual Studio Code and click File > Open folder and select the directory with your new repository.
 
 {% include links.md %}

--- a/setup.md
+++ b/setup.md
@@ -74,7 +74,7 @@ Python 3.12.3
 ```
 {:code}
 
-If this command returns something like `command not found: python3` then install python using the instructions on[https://docs.pytest.org/en/stable/getting-started.html](https://docs.pytest.org/en/stable/getting-started.html).
+If this command returns something like `command not found: python3` then install python using the instructions on[https://wiki.python.org/moin/BeginnersGuide/Download](https://wiki.python.org/moin/BeginnersGuide/Download).
 
 #### Git & GitHub
 


### PR DESCRIPTION
Add basic setup instructions for all the requirements.

Since the time for this is so short, and it's probably going to be on the first day (going off last year's schedule), I'm not going to assume people have everything installed locally. I know that getting things installed can be a pain, so I'll recommend people use a Codespace on GitHub if they don't already have things set up, and we can help them out with the local setup afterwards.

- resolves #34 