### PR TITLE
docs: add examples of upper cap

### DIFF
--- a/_episodes/04-metadata.md
+++ b/_episodes/04-metadata.md
@@ -196,7 +196,7 @@ You need to make sure you always have this line and that it stays accurate, sinc
 
 > ## Upper caps
 >
-> Upper caps are generally discouraged in the Python ecosystem, but they are (even more than usual) broken when used with `requires-python` field. This field was added to help users drop old Python versions, and the idea it would be used to restrict newer versions was not considered. The above field is not the right one to set an upper cap! Never upper cap this field and instead use classifiers to tell users what versions of Python your code was tested with.
+> Upper caps (like `">=3.8,<4` or `"~=3.8"`) are generally discouraged in the Python ecosystem, but they are broken (even more than usual) when used with `requires-python` field. This field was added to help users drop old Python versions, and the idea it would be used to restrict newer versions was not considered. The above field is not the right one to set an upper cap! Never upper cap this field and instead use classifiers to tell users what versions of Python your code was tested with.
 {:.callout}
 
 ### Dependencies


### PR DESCRIPTION
Added examples, since a learner might not know what is meant by upper caps. There is a numpy one much further down on the page, but having it here and including the very common <4 example seems helpful.
