### PR TITLE
fix: nicer nox usage for builder

### DIFF
--- a/_episodes/06.1-documentation-sphinx.md
+++ b/_episodes/06.1-documentation-sphinx.md
@@ -85,12 +85,47 @@ docs = [
 
 You can install these dependencies using `pip install --editable ".[docs]".
 
-To run the Sphinx preview server, you can run the following:
+To run the Sphinx preview server, you can install `sphinx-autobuild`, then run:
 
 ```bash
-sphinx-build -b html "./docs" "_build/html"
-python -m http.server 8000 -d _build/html
+sphinx-autobuild --open-browser -b html "./docs" "_build/html"
 ```
+
+This will rebuild if you change files, as well.
+
+## Nox session
+
+You can set up a task runner like nox to run this for you:
+
+```python
+@nox.session(reuse_venv=True)
+def docs(session: nox.Session) -> None:
+    """
+    Build the docs. Use "--non-interactive" to avoid serving.
+    """
+
+    serve = session.interactive
+    extra_installs = ["sphinx-autobuild"] if serve else []
+    session.install("-e.[docs]", *extra_installs)
+
+    session.chdir("docs")
+
+    shared_args = (
+        "-n",  # nitpicky mode
+        "-T",  # full tracebacks
+        "-b=html",
+        ".",
+        f"_build/html",
+        *posargs,
+    )
+
+    if serve:
+        session.run("sphinx-autobuild", "--open-browser", *shared_args)
+    else:
+        session.run("sphinx-build", "--keep-going", *shared_args)
+```
+
+And you now have working docs that you can generate and view cross platform with `nox -s docs`!
 
 ## Read the Docs
 

--- a/_episodes/06.1-documentation-sphinx.md
+++ b/_episodes/06.1-documentation-sphinx.md
@@ -116,7 +116,7 @@ def docs(session: nox.Session) -> None:
         "-b=html",
         ".",
         f"_build/html",
-        *posargs,
+        *session.posargs,
     )
 
     if serve:


### PR DESCRIPTION
Better example. I removed the `-b` option from https://github.com/scikit-build/scikit-build-core/blob/a805267a6c08aeb2485a55f89aa62ab0798e9a0b/noxfile.py#L130-L160 to simplify, though that is handy for link check, man pages, and PDFs.
