### PR TITLE
update url check ci

### DIFF
--- a/.github/workflows/check-pr-urls.yml
+++ b/.github/workflows/check-pr-urls.yml
@@ -27,7 +27,7 @@ jobs:
 
       # Run URL checks
       - name: URLs-checker
-        uses: urlstechie/urlchecker-action@0.0.33
+        uses: urlstechie/urlchecker-action@0.0.34
         with:
           # only include the changed files
           include_files: ${{ steps.files.outputs.added_modified }}


### PR DESCRIPTION
* URL check was failing on push. Checking-out with fetch depth = 2 resolved the problem. 
* Updated actions to latest versions for good measure

