### PR TITLE
Fix list formatting

### DIFF
--- a/episodes/checks.md
+++ b/episodes/checks.md
@@ -4,8 +4,7 @@ teaching: 10
 exercises: 10
 ---
 
-
-:::::::::::::::::::::::::::::::::::::: questions 
+:::::::::::::::::::::::::::::::::::::: questions
 
 - How do you ensure your code will work well?
 
@@ -18,8 +17,8 @@ exercises: 10
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-
 In this episode we'll give an introduction to setting up your project for
+
 - tests with `pytest`, and
 - static checks (also known as linters, formatters, and type checkers).
 
@@ -37,8 +36,6 @@ There are several options for test directory. The recommendation is `/tests`
 (with an `s`), at the root of your repository. Combined with `/src/<package>`
 layout, you will have the best experience avoiding weird edge cases with package
 importing.
-
-
 
 ::::::::::::::::::::::::::::::::::::: discussion
 
@@ -76,13 +73,13 @@ testpaths = [
   - `--strict-markers` will make sure you don't try to use an unspecified fixture.
   - And `--strict-config` will error if you make a mistake in your config.
 - `xfail_strict` will change the default for `xfail` to fail the
-tests if it doesn't fail - you can still override locally in a specific xfail
-for a flaky failure.
+  tests if it doesn't fail - you can still override locally in a specific xfail
+  for a flaky failure.
 - `filter_warnings` will cause all warnings to be errors
-(you can add allowed warnings here too, see below).
+  (you can add allowed warnings here too, see below).
 - `log_cli_level` will report `INFO` and above log messages on a failure.
 - Finally, `testpaths` will limit `pytest` to just looking in the folders given - useful if it tries to pick up
-things that are not tests from other directories.
+  things that are not tests from other directories.
 
 [See the docs](https://docs.pytest.org/en/stable/customize.html) for more options.
 
@@ -109,7 +106,6 @@ becoming errors using the syntax
 `"<action>:Regex for warning message:Warning:package"`, where `<action>` can
 tends to be `default` (show the first time) or `ignore` (never show). The regex
 matches at the beginning of the error unless you prefix it with `.*`.
-
 
 ## Static checks
 
@@ -149,11 +145,13 @@ lint.extend-select = [
 ```
 
 To use Ruff to check your code for style problems, run:
+
 ```bash
 pipx run ruff check
 ```
 
 To use Ruff to format your code, run:
+
 ```bash
 pipx run ruff format
 ```
@@ -195,18 +193,18 @@ well worth it - a static type checker can catch many things, and doesn't require
 writing tests!
 
 To run mypy, you can call:
+
 ```bash
 pipx run mypy --python-executable .venv/bin/python .
 ```
 
-- mypy needs the argument  `--python-executable .venv/bin/python`
+- mypy needs the argument `--python-executable .venv/bin/python`
   to access to the version of the Python interpreter you are using for your project.
   It uses this to get access to type information for imported packages (like numpy).
 - You also need to give it a path to a directory containing files to check, in this case `.`.
 
 You can learn about configuring mypy in the
 [Scientific-Python Development Guide](https://learn.scientific-python.org/development/guides/mypy/).
-
 
 ### The pre-commit framework
 
@@ -264,8 +262,8 @@ especially useful in the "installed" mode (where only staged changes are
 checked).
 
 To configure Ruff within `.pre-commit-config.yaml`, add the following configuration:
-```yaml
 
+```yaml
 - repo: https://github.com/charliermarsh/ruff-pre-commit
   rev: "v0.5.2"
   hooks:
@@ -277,12 +275,12 @@ To configure Ruff within `.pre-commit-config.yaml`, add the following configurat
 To configure mypy within `.pre-commit-config.yaml`, add the following configuration:
 
 ```yaml
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.10.0"
-    hooks:
-      - id: mypy
-        files: src
-        args: []
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: "v1.10.0"
+  hooks:
+    - id: mypy
+      files: src
+      args: []
 ```
 
 You will need to add `additional_dependencies: [numpy]` as the pre-commit `mypy`
@@ -304,11 +302,7 @@ See the Style guide at
 [Scientific-Python Development Guide](https://learn.scientific-python.org/development/guides/style)
 for a lot more suggestions on static checking.
 
-
-
-
-
-:::::::::::::::::::::::::::::::::::::: keypoints 
+:::::::::::::::::::::::::::::::::::::: keypoints
 
 - Run tests and static checks on your codebase.
 

--- a/episodes/code-to-package.md
+++ b/episodes/code-to-package.md
@@ -4,7 +4,7 @@ teaching: 20
 exercises: 5
 ---
 
-:::::::::::::::::::::::::::::::::::::: questions 
+:::::::::::::::::::::::::::::::::::::: questions
 
 - How do we take code and turn that into a package?
 - What are the minimum elements required for a Python package?
@@ -19,9 +19,6 @@ exercises: 5
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-
-
-
 Much research software is initially developed by hacking away in an interactive setting,
 such as in a [Jupyter Notebook](https://jupyter.org) or a Python shell.
 However, at some point when you have a more-complicated workflow that you want to repeat,
@@ -29,23 +26,22 @@ and/or make available to others,
 it makes sense to package your functions into modules and ultimately a software package that can be installed.
 This lesson will walk you through that process.
 
-
 ::::::::::::::::::::::::::::::::::::: callout
 
 - Ensure you're in an empty git repository (see [Setup](../learners/setup.md) for details).
 - Ensure you've created and activated your virtual environment (see [Environment](environment.md) for details):
+
 ```bash
 . .venv/bin/activate
 ```
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-
 Consider the `rescale()` function written as an exercise in the Software Carpentry
 [Programming with Python](https://swcarpentry.github.io/python-novice-inflammation/08-func/index.html) lesson.
 
-
 Install NumPy:
+
 ```bash
 pip install numpy
 ```
@@ -80,13 +76,13 @@ which provides the output:
 array([ 0.  ,  0.25,  0.5 ,  0.75,  1.  ])
 ```
 
-
 ## Create a minimal package
 
 Let's create a Python package that contains this function.
 
 Create the necessary directory structure for your package.
 This includes:
+
 - a `src` ("source") directory, which will contain another directory called `package` for the source files of your package itself,
 - a `tests` directory, which will hold tests for your package and its modules/functions,
 - a `docs` directory, which will hold the files necessary for documenting your software package.
@@ -111,7 +107,9 @@ We are straying from this convention in this tutorial to prevent naming conflict
 ::::::::::::::::::::::::::::::::::::: callout
 
 ## Directory Structure
-Putting the package directory and source code inside the `src` directory is not actually *required*.
+
+Putting the package directory and source code inside the `src` directory is not actually _required_.
+
 - If you put the `<package_name>` directory at the same level as `tests` and `docs` then you could actually import or call the package directory from that location.
 - However, this can cause several issues, such as running tests with the local version instead of the installed version.
 - In addition, the `src/` package structure matches that of compiled languages, and lets your package easily contain non-Python compiled code, if necessary.
@@ -138,6 +136,7 @@ $ touch pyproject.toml
 ```
 
 and then provide the minimally required metadata, which include
+
 - information about the package itself (`name`, `version` and `dependencies`) and
 - build system (hatchling):
 
@@ -163,6 +162,7 @@ and how to specify this without manually writing it here.
 ::::::::::::::::::::::::::::::::::::: callout
 
 ## Build Backend
+
 The build backend is a program which will convert the source files into a package
 ready for distribution. It determines how your project will specify
 its configuration, metadata and files.
@@ -176,10 +176,10 @@ There are other backends too, including ones for
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-
 ::::::::::::::::::::::::::::::::::::: callout
 
 ## Minimal Working Package
+
 The only elements of your package strictly _required_ to install and import it are
 the `pyproject.toml`, `__init__.py`, and `rescale.py` files.
 
@@ -237,6 +237,7 @@ touch tests/test_rescale.py
 ```
 
 In this file, we need to import the package, and check that a call to the `rescale` function with our known input returns the expected output:
+
 ```python
 # contents of tests/test_rescale.py
 import numpy as np
@@ -270,11 +271,13 @@ test = ["pytest"]
 ```
 
 You install the project with the "extra" using:
+
 ```bash
 pip install --editable ".[test]"
 ```
 
 You can run the tests using `pytest`:
+
 ```
 (.venv) % pytest
 ======================== test session starts ========================
@@ -290,13 +293,11 @@ tests/test_rescale.py .                                       [100%]
 
 This tells us that the output of the test function matches the expected result, and therefore the test passes! 🎉
 
-
 ## Commit and Push
 
 Don't forget to commit all your work using `git`.
 (In the rest of the lesson, we won't remind you to do this,
 but you should still make small commits regularly.)
-
 
 Commit the relevant files, first the code:
 
@@ -307,12 +308,14 @@ git commit -m "feat: add basic rescaling function
 ```
 
 ... then the metadata:
+
 ```bash
 git add pyproject.toml
 git commit -m "build: add minimal pyproject.toml"
 ```
 
 ... then push those to the `origin` remote repository.
+
 ```bash
 git push origin main
 ```
@@ -322,6 +325,7 @@ git push origin main
 ## Always `git add` individual files until you've set up your `.gitignore`
 
 When working with git, it's best to
+
 - stage **individual files** using `git add FILENAME ...`,
 - check what you're about to commit using `git status`, before you
 - commit with `git commit -m "COMMIT MESSAGE"`.
@@ -338,67 +342,60 @@ and is a prerequisite for using `git commit -a` which commits everything.
 ::::::::::::::::::::::::::::::::::::: callout
 
 ## Conventional commits
+
 In this example, we use
 [conventional commit messages](https://www.conventionalcommits.org/)
 which look like `<type>: <description>`.
 
 Each commit should do one and only one "thing" to the code, for instance:
-- add a new feature (type: `feat`), *or*
-- fix a bug (type: `fix`), *or*
-- rename a function (type: `refactor`), *or*
-- add documentation (type: `docs`), *or*
+
+- add a new feature (type: `feat`), _or_
+- fix a bug (type: `fix`), _or_
+- rename a function (type: `refactor`), _or_
+- add documentation (type: `docs`), _or_
 - change something affecting the build system (type: `build`).
 
 By doing only one thing per commit, it's easier to:
+
 - write the commit message,
 - understand the history by looking at the `git log`, and
 - revert individual changes you later decide could be done in a better way.
 
-
 ::::::::::::::::::::::::::::::::::::::::::::::::
-
-
-
-
 
 ::::::::::::::::::::::::::::::::::::: challenge
 
 ## Check your package
+
 Check that you can install your package and that it works as expected.
 
 If everything works, you should be able to install your package (in a new virtual environment):
+
 ```
 python3 -m venv .venv2
 . .venv2/bin/activate
 python3 -m pip install git+https://github.com/<your github username>/example-package-YOUR-USERNAME-HERE
 ```
+
 Open a python console and call the rescale function with some data.
 
 Switch back to the original virtual environment before going onto the next lesson:
+
 ```
 . .venv/bin/activate
 ```
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-
 You now have a package that is:
+
 - installed in editable mode in an isolated environment,
 - can be interacted with in tests and in an interactive console, and
 - has a passing test.
 
 Next, we'll look at other files that should be included with your package.
 
-
-
-
-
-
-
-
-
-
-:::::::::::::::::::::::::::::::::::::: keypoints 
+:::::::::::::::::::::::::::::::::::::: keypoints
 
 - Put your code and tests in a standard package structure
 - Use a `pyproject.toml` file to describe a Python package

--- a/episodes/continuous-integration.md
+++ b/episodes/continuous-integration.md
@@ -4,7 +4,7 @@ teaching: 10
 exercises: 10
 ---
 
-:::::::::::::::::::::::::::::::::::::: questions 
+:::::::::::::::::::::::::::::::::::::: questions
 
 - How do you ensure code keeps passing
 
@@ -16,31 +16,33 @@ exercises: 10
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-
 Developers often need to run some tasks every time they update code.
 This might include running tests, or checking that the formatting
 conforms to a style guide.
 
 ========
 questions:
+
 - "How do you ensure code keeps passing"
-objectives:
+  objectives:
 - "Use a CI service to run your tests"
-keypoints:
+  keypoints:
 - "Set up GitHub Actions on your project"
 - "Run your tests on multiple platforms and with multiple Python versions"
+
 ---
 
 Developers often need to run some tasks every time they update code.
 This might include running tests, or checking that the formatting
 conforms to a style guide.
 
->>>>>>>> 9daa45e1661bdd97637ab402d79599816dd04f3b:episodes/10-continuous-integration.md
-Continuous Integration (CI) allows the developer to automate running
-these kinds of tasks each time various "trigger" events occur on your repository.
-For example, you can use CI to run a test suite on every pull request.
+> > > > > > > > 9daa45e1661bdd97637ab402d79599816dd04f3b:episodes/10-continuous-integration.md
+> > > > > > > > Continuous Integration (CI) allows the developer to automate running
+> > > > > > > > these kinds of tasks each time various "trigger" events occur on your repository.
+> > > > > > > > For example, you can use CI to run a test suite on every pull request.
 
 In this episode we will set up CI using GitHub Actions:
+
 - test the code on every pull request or merge to main,
 - run those tests under multiple versions of python, on Linux, Windows and macOS.
 
@@ -72,8 +74,6 @@ Let's set up a basic test. We will define a jobs dict, with a single job named
 "tests". For all jobs, you need to select an image to run on - there are images
 for Linux, macOS, and Windows. We'll use `ubuntu-latest`.
 
-
-
 ```yaml
 on:
   pull_request:
@@ -98,7 +98,6 @@ jobs:
         run: python -m pytest
 ```
 
-
 This has five steps:
 
 1. Checkout the source (your repo).
@@ -108,13 +107,11 @@ This has five steps:
 
 By default, if any step fails, the run immediately quits and fails.
 
-
 ## Running in a matrix
 
 You can parametrize values, such as Python version or operating system. Do do this, make a `strategy: matrix:` dict. Every key in that dict (except `include:` and `exclude` should be set with a list, and a job will be generated with every possible combination of values. You can access these values via the `matrix` variable; they do not "automatically" change anything.
 
 For example:
-
 
 ```yaml
 example:
@@ -124,14 +121,10 @@ example:
   name: Job ${{ matrix.onetwothree }}
 ```
 
-
-
 would produce three jobs, with names `Job 1`, `Job 2`, and `Job 3`. Elsewhere,
 if you refer to the `example` job, it will implicitly refer to all three.
 
 This is commonly used to set Python and operating system versions:
-
-
 
 ```yaml
 on:
@@ -165,8 +158,6 @@ jobs:
       - name: Test package
         run: python -m pytest
 ```
-
-
 
 There are two special keys: `include:` will take a list of jobs to include one
 at a time. For example, you could add Python 3.9 on Linux (but not the others):
@@ -204,7 +195,6 @@ And many other useful ones:
 - [conda-incubator/setup-miniconda](https://github.com/conda-incubator/setup-miniconda): Setup conda or mamba on GitHub Actions.
 - [ruby/setup-miniconda](https://github.com/ruby/setup-ruby) Setup Ruby if you need it for something.
 
-
 ::::::::::::::::::::::::::::::::::::: challenge
 
 ## Exercise
@@ -213,10 +203,7 @@ Add a CI file for your package.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-
-
-
-:::::::::::::::::::::::::::::::::::::: keypoints 
+:::::::::::::::::::::::::::::::::::::: keypoints
 
 - Set up GitHub Actions on your project
 - Run your tests on multiple platforms and with multiple Python versions

--- a/episodes/documentation-mkdocs-material.md
+++ b/episodes/documentation-mkdocs-material.md
@@ -4,7 +4,7 @@ teaching: 10
 exercises: 10
 ---
 
-:::::::::::::::::::::::::::::::::::::: questions 
+:::::::::::::::::::::::::::::::::::::: questions
 
 - How do I document my project?
 
@@ -16,18 +16,17 @@ exercises: 10
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-
 In this lesson, we'll outline creating a documentation webpage
 using the [MkDocs](https://www.mkdocs.org/) framework
 with the [Material](https://squidfunk.github.io/mkdocs-material/) theme.
 
 You will:
+
 - add the necessary dependencies to your `pyproject.toml` file,
 - set up a basic documentation directory,
 - create a configuration which comes with a table of contents by default,
 - start a preview server,
 - add a page which includes a code listing for your `rescale` function.
-
 
 ## Dependencies
 
@@ -45,7 +44,6 @@ docs = [
 
 ... then reinstall using `pip install --editable ".[docs]"`.
 
-
 ::::::::::::::::::::::::::::::::::::: callout
 
 ## `doc` or `docs`
@@ -58,11 +56,13 @@ for the name of this extra is `doc`, whereas `docs` is ~3x more popular.
 ## Template
 
 Create an empty site using:
+
 ```bash
 mkdocs new .
 ```
 
 This will create files and directories as follows:
+
 ```
 .
 ├─ docs/
@@ -87,6 +87,7 @@ theme:
 ::::::::::::::::::::::::::::::::::::: callout
 
 ## `site_url` is important
+
 It is important to set the `site_url` because it's assumed to be set by a number of plugins.
 
 It's set here to a [GitHub Pages](https://pages.github.com/) address –
@@ -94,7 +95,6 @@ you can set it to `https://<your github username>.github.io/example-package-YOUR
 or any other domain where you want to publish.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
-
 
 ## Preview
 
@@ -110,6 +110,7 @@ And add (a correct) `docs/index.md` yourself:
 
 ````md
 <!--- docs/index.md -->
+
 # Example Package YOUR USERNAME HERE
 
 `example-package-YOUR-USERNAME-HERE` is a simple Python library that contains a single function for rescaling arrays.
@@ -117,6 +118,7 @@ And add (a correct) `docs/index.md` yourself:
 ## Installation
 
 You can install the package by calling:
+
 ```bash
 pip install git+https://github.com/<your github username>/example-package-YOUR-USERNAME-HERE
 ```
@@ -130,12 +132,12 @@ from example_package_YOUR_USERNAME_HERE.rescale import rescale
 # rescales over 0 to 1
 rescale(np.linspace(0, 100, 5))
 ```
-
 ````
 
 ::::::::::::::::::::::::::::::::::::: callout
 
 ## `README.md` vs `index.md`
+
 Often, similar information will be contained in the repository README
 and the index page of the documentation – installation instructions,
 basic usage, licensing etc., and so it's common to want to include
@@ -162,7 +164,7 @@ We'll add a new page to the documentation with the docstrings from the package.
   ```yaml
   # mkdocs.yml
   plugins:
-  - mkdocstrings
+    - mkdocstrings
   ```
 
 - Include the `mkdocstrings[python]` package in the `docs` dependencies of the pyprojects.toml:
@@ -185,7 +187,7 @@ We'll add a new page to the documentation with the docstrings from the package.
   ```
 
 - Stop the preview server using <kbd>Ctrl</kbd>-<kbd>C</kbd>
-- Reinstall using `pip install --editable ".[docs]"`  since we added a new dependency
+- Reinstall using `pip install --editable ".[docs]"` since we added a new dependency
 - Reload the documentation preview using `mkdocs serve`
 
 MkDocs automatically adds the additional page to your documentation.
@@ -193,6 +195,7 @@ MkDocs automatically adds the additional page to your documentation.
 ## Publish to GitHub Pages
 
 To publish the documentation to GitHub pages, run:
+
 ```bash
 mkdocs gh-deploy
 ```
@@ -224,7 +227,6 @@ Try adding another page.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-
 ::::::::::::::::::::::::::::::::::::: callout
 
 ## Further reading
@@ -234,8 +236,7 @@ Try adding another page.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-
-:::::::::::::::::::::::::::::::::::::: keypoints 
+:::::::::::::::::::::::::::::::::::::: keypoints
 
 - MkDocs is great for documentation
 

--- a/episodes/documentation-sphinx.md
+++ b/episodes/documentation-sphinx.md
@@ -4,7 +4,7 @@ teaching: 10
 exercises: 10
 ---
 
-:::::::::::::::::::::::::::::::::::::: questions 
+:::::::::::::::::::::::::::::::::::::: questions
 
 - How do I document my project?
 
@@ -16,11 +16,10 @@ exercises: 10
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-
-
 In this lesson, we'll outline creating a documentation webpage using Sphinx.
 
 You will:
+
 - set up a basic documentation directory,
 - create a configuration including the modern MyST plugin to get markdown support,
 - start a preview server,
@@ -34,7 +33,7 @@ You will:
 We'll start with the built-in template. Start by creating a `docs/` directory
 within your project (i.e. next to `src/`).
 
-::::::::::::::::::::::::::::::::::::: spoiler 
+::::::::::::::::::::::::::::::::::::: spoiler
 
 ## Why not Sphinx-Quickstart?
 
@@ -47,7 +46,6 @@ pipx run --spec sphinx sphinx-quickstart --no-makefile --no-batchfile --ext-auto
 But this will put Restructured Text into the `index.md` file, and doesn't really generate that much for you. You can instead add the `docs/conf.py` file yourself, which is what we'll do here.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
-
 
 You first file is a configuration file, `docs/conf.py`:
 
@@ -74,9 +72,9 @@ And add (a correct) `docs/index.md` yourself:
 
 ## Indices and tables
 
-* {ref}`genindex`
-* {ref}`modindex`
-* {ref}`search`
+- {ref}`genindex`
+- {ref}`modindex`
+- {ref}`search`
 ````
 
 As you add new pages, you will list them in the toctree above.
@@ -181,6 +179,7 @@ If you want to include your readme in your docs, you can add something like this
 
 And you use `<!-- SPHINX-START -->` to mark where you want your docs part of
 your `README.md` to start (generally after the title and badges).
+
 ```markdown
 # Example Package YOUR USERNAME HERE
 
@@ -190,7 +189,6 @@ your `README.md` to start (generally after the title and badges).
 ```
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
-
 
 ::::::::::::::::::::::::::::::::::::: checklist
 
@@ -206,7 +204,6 @@ And add `"furo"` to your `docs` extra in your `pyproject.toml`.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-
 ::::::::::::::::::::::::::::::::::::: callout
 
 ## Further reading
@@ -215,11 +212,7 @@ To see a more complete example, read [Scientific-Python's docs guide](https://le
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-
-
-
-
-:::::::::::::::::::::::::::::::::::::: keypoints 
+:::::::::::::::::::::::::::::::::::::: keypoints
 
 - Sphinx is great for documentation
 

--- a/episodes/environment.md
+++ b/episodes/environment.md
@@ -23,6 +23,7 @@ One of Python's biggest strengths is its ecosystem of packages which build upon 
 the capabilities offered by the standard library.
 
 We'll look at how:
+
 - You should use virtual environments to manage the dependencies of different projects,
 - You can install packages you want to build on using `pip`, and
 - You can install Python applications you just want to use using `pipx`.
@@ -40,6 +41,7 @@ python3 -m venv .venv
 ```
 
 This creates a new directory `.venv` containing:
+
 - `.venv/bin`
   - A link to the Python version,
   - A link to the Python package installer `pip`, and
@@ -116,6 +118,7 @@ conda deactivate
 ```
 
 Alternative implementations of `conda` are available and may be faster, like:
+
 - [Micromamba](https://mamba.readthedocs.io/en/latest/user_guide/micromamba.html)
    a single binary, also written in C++,
 - [Pixi](https://github.com/prefix-dev/pixi) written in Rust.

--- a/episodes/environment.md
+++ b/episodes/environment.md
@@ -4,7 +4,7 @@ teaching: 10
 exercises: 10
 ---
 
-:::::::::::::::::::::::::::::::::::::: questions 
+:::::::::::::::::::::::::::::::::::::: questions
 
 - How do you install and manage packages?
 - How can you ensure others run the same code you do?
@@ -17,7 +17,6 @@ exercises: 10
 - Use a task runner to manage environments and run code
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
-
 
 One of Python's biggest strengths is its ecosystem of packages which build upon and extend
 the capabilities offered by the standard library.
@@ -56,22 +55,21 @@ To activate the environment, source the activation script:
 
 Now `.venv/bin` has been added to your PATH, and usually your shell's prompt
 will be modified to indicate you are "in" a virtual environment:
+
 ```
 % . .venv/bin/activate
 (.venv) %
 ```
 
-
-
-:::::::::::::::::::::::::::::::::::::: challenge 
+:::::::::::::::::::::::::::::::::::::: challenge
 
 ## Upgrade `pip`
+
 Check the version of pip installed!
 If it's old, you might want to run `pip install --upgrade pip` or,
 for Python 3.9 or later, you can add `--upgrade-deps` to the venv creation line.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
-
 
 To "leave" the virtual environment, you
 undo those changes by running the deactivate function the activation added to
@@ -88,7 +86,7 @@ The prompt will revert:
 %
 ```
 
-:::::::::::::::::::::::::::::::::::::: callout 
+:::::::::::::::::::::::::::::::::::::: callout
 
 ## Alternatives
 
@@ -104,7 +102,8 @@ by default (since you are supposed to use `uv pip`).
 Use the tool you prefer; the resulting venv works identically.
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-:::::::::::::::::::::::::::::::::::::: callout 
+:::::::::::::::::::::::::::::::::::::: callout
+
 ## What about conda?
 
 The same concerns apply to Conda. You should always make separate environments and
@@ -120,7 +119,7 @@ conda deactivate
 Alternative implementations of `conda` are available and may be faster, like:
 
 - [Micromamba](https://mamba.readthedocs.io/en/latest/user_guide/micromamba.html)
-   a single binary, also written in C++,
+  a single binary, also written in C++,
 - [Pixi](https://github.com/prefix-dev/pixi) written in Rust.
 
 [Mamba](https://github.com/mamba-org/mamba), written in C++,
@@ -129,7 +128,6 @@ In 2023, `conda` incorporated the `libmamba` package resolver as its default,
 largely eliminating the speed difference between `conda` and `mamba`.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
-
 
 ## Installing Packages
 
@@ -141,15 +139,17 @@ then call:
 pip install <package>
 ```
 
+:::::::::::::::::::::::::::::::::::::: challenge
 
-:::::::::::::::::::::::::::::::::::::: challenge 
 ## Install `numpy`
 
 - Install the numpy package into your virtual environment.
 - Test it by opening a Python session and running `import numpy as np` then `np.arange(15).reshape(3, 5)`.
 
-:::::::::::::::::::::::::::: solution 
+:::::::::::::::::::::::::::: solution
+
 ## Solution
+
 ```
 % . .venv/bin/activate
 (.venv) % pip install numpy
@@ -164,12 +164,11 @@ array([[ 0,  1,  2,  3,  4],
 >>> exit()
 (.venv) %
 ```
+
 :::::::::::::::::::::::::::::::::::::
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-
-
-:::::::::::::::::::::::::::::::::::::: caution 
+:::::::::::::::::::::::::::::::::::::: caution
 
 ## Installing Packages in the "base" and "user" environment
 
@@ -181,15 +180,17 @@ which you should use unless you know what you're doing:
 ```bash
 pip install <package>         # Use only in virtual environment!
 ```
+
 Unless you've activated a virtual environment,
 this will try to install globally, and if you don't have permission, will install to your
 user site packages. In global site packages, you can get conflicting versions
 of libraries, you can't tell what you've installed for what, packages can
-update and break your system; it's a mess. This is the *"update problem"*.
+update and break your system; it's a mess. This is the _"update problem"_.
 
 ```bash
 pip install --user <package>  # Almost never use
 ```
+
 This will install in your user directory. This is even worse worse,
 because all installs of Python on your computer share it, so you might override
 and break things you didn't intend to. And with pip's new smart solver,
@@ -202,6 +203,7 @@ There is a solution: virtual environments (libraries) or pipx (applications).
 There are likely a _few_ libraries (ideally just `pipx`) that you just have to
 install globally. Go ahead, but be careful, and always use your system package
 manager instead if you can, like
+
 - [`brew` on macOS](https://brew.sh),
 - [`winget`](https://learn.microsoft.com/en-us/windows/package-manager/winget/) or [`scoop`](https://scoop.sh/) on Windows,
 - `apt-get` on Ubuntu.
@@ -225,20 +227,19 @@ run a script of the same name, and will cache the temporary environment for a
 week. This means you have all of PyPI at your fingertips in one line on any
 computer that has pipx installed!
 
-
-
-:::::::::::::::::::::::::::::::::::::: challenge 
+:::::::::::::::::::::::::::::::::::::: challenge
 
 ## Install `pipx` and `cowsay`
 
 - Install `pipx` by following the [installation instructions](https://pipx.pypa.io/).
 - Test it by running `pipx run cowsay -t "venvs are the foo\!"`
 
-:::::::::::::::::::::::::::: solution 
+:::::::::::::::::::::::::::: solution
 
 ## Solution
 
 Ubuntu Linux:
+
 ```command
 sudo apt update
 sudo apt install pipx
@@ -246,12 +247,14 @@ pipx ensurepath
 ```
 
 macOS:
+
 ```command
 brew install pipx
 pipx ensurepath
 ```
 
 Then:
+
 ```command
 % pipx run cowsay -t "venvs are the foo\!"
   __________________
@@ -269,9 +272,7 @@ Then:
 :::::::::::::::::::::::::::::::::::::
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-
-
-:::::::::::::::::::::::::::::::::::::: keypoints 
+:::::::::::::::::::::::::::::::::::::: keypoints
 
 - Virtual environments isolate software
 - Virtual environments solve the update problem

--- a/episodes/metadata.md
+++ b/episodes/metadata.md
@@ -4,7 +4,7 @@ teaching: 10
 exercises: 5
 ---
 
-:::::::::::::::::::::::::::::::::::::: questions 
+:::::::::::::::::::::::::::::::::::::: questions
 
 - What metadata is important to add to your package?
 - How do I add common functionality, like executable scripts?
@@ -17,16 +17,14 @@ exercises: 5
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-
-
-
-
 In a previous lesson, we left the metadata in our `pyproject.toml` quite minimal, just:
+
 - a name and
 - a version.
 
 There are quite a few other fields that can really help your package on PyPI, however.
 We'll look at them, split into categories:
+
 - Informational: author, description, URL, etc.
 - Functional: requirements, tool configurations etc.
 
@@ -52,17 +50,13 @@ version = "1.2.3"
 version = "0.2.1b1"
 ```
 
-
 ### Description
 
 A string with a short description of your project.
 
-
 ```toml
 description = "This is a very short summary of a very cool project."
 ```
-
-
 
 ### Readme
 
@@ -148,6 +142,7 @@ classifiers = [
 ::::::::::::::::::::::::::::::::::::: callout
 
 ## Prevent Inadvertent Publishing
+
 By adding the "Private :: Do Not Upload" classifier here, we ensure that
 the package will be
 [rejected when we try to upload it to PyPI](https://pypi.org/classifiers/#:~:text=To%20prevent%20a%20package%20from,beginning%20with%20%22Private%20%3A%3A%22.).
@@ -158,6 +153,7 @@ If you want to upload to PyPI, you will need to remove that classifier.
 ### License
 
 There are three ways to include your license:
+
 1. The preferred way to include a standard license
    is to include a classifier starting with "License ::",
    ```toml
@@ -174,10 +170,12 @@ There are three ways to include your license:
    ```
 3. You may also put the license in a file named `LICENSE` or `LICENSE.txt`
    and link it in the `license` field:
+
    ```toml
    [project]
    license = {file = "LICENSE"}
    ```
+
    If you do this, after the [`build` step](publishing.md),
    verify the contents of your SDist and Wheel(s) manually
    to make sure the license file is included,
@@ -240,11 +238,13 @@ plot = ["matplotlib"]
 ```
 
 Now you can run:
+
 ```bash
 pip install --editable '.[test,check]'
 ```
 
 or – once it's published,
+
 ```bash
 pip install 'example-package-YOUR-USERNAME-HERE[test,check]'
 ```
@@ -254,15 +254,16 @@ but not `matplotlib`.
 
 #### Setting minimum, maximum and specific versions of dependencies
 
-*Whether* you set versions on dependencies depends on what sort of package you are working on:
+_Whether_ you set versions on dependencies depends on what sort of package you are working on:
 
-* **Library**: something that can be imported. Support the widest range you are able to test.
+- **Library**: something that can be imported. Support the widest range you are able to test.
   If you have very few users, requiring recent versions of dependencies is probably fine.
   If you expect a large number of users, you should support (and test!) a few past releases of dependencies.
-* **App (CLI/GUI/TUI)**: Something that is installable but not importable. Wide range preferred, but not as important (assuming users use pipx and don't add it to "dev" environments or things like that).
-* **Application (deployment)**: Something like a website or an analysis. Not installable. Versions should be fully locked.
+- **App (CLI/GUI/TUI)**: Something that is installable but not importable. Wide range preferred, but not as important (assuming users use pipx and don't add it to "dev" environments or things like that).
+- **Application (deployment)**: Something like a website or an analysis. Not installable. Versions should be fully locked.
 
 You can set ranges on your dependencies by specifying the ranges in the `pyproject.toml` file:
+
 ```toml
 dependencies = [
   "tqdm",                # no specified range
@@ -276,6 +277,7 @@ dependencies = [
 If you have a range of versions supported, you should ideally
 run your tests at least once with the minimum versions of your dependencies.
 You can do this using:
+
 - a `constraints.txt` file,
   which specifies pins on the minimum versions of all your dependencies, and
   then use `pip install --constraint constraints.txt --editable .` before running your tests .
@@ -289,6 +291,7 @@ For more information, see this article on
 [bound version constraints](https://iscinumpy.dev/post/bound-version-constraints/).
 
 There are several ways to lock your dependencies completely:
+
 - specify the versions in the `pyproject.toml` file, or
 - allow ranges in the `pyproject.toml` file and
   - specify the versions for your development environment manually using `pip-tools`, or
@@ -300,6 +303,7 @@ There are several ways to lock your dependencies completely:
 ::::::::::::::::::::::::::::::::::::: callout
 
 ## Pinning Dependencies with `pip-tools`
+
 Set up a `requirements.in` file with your unpinned dependencies. For example:
 
 ```txt
@@ -314,10 +318,9 @@ pipx run --spec pip-tools pip-compile requirements.in --generate-hashes
 ```
 
 This will produce a `requirements.txt` with fully locked dependencies, including
-hashes.  You can always regenerate it when you want updates.
+hashes. You can always regenerate it when you want updates.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
-
 
 ::::::::::::::::::::::::::::::::::::: challenge
 
@@ -334,7 +337,6 @@ What is the difference between `project.dependencies` vs. `build-system.requires
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
-
 
 ### Entry Points
 
@@ -362,7 +364,6 @@ version.path = "src/example_package_YOUR_USERNAME_HERE/__init__.py"
 ```
 
 ## All together
-
 
 Now let's take our previous example and expand it with more information. Here's an example:
 
@@ -401,6 +402,7 @@ test = ["pytest"]
 ::::::::::::::::::::::::::::::::::::: challenge
 
 ## Add metadata and check it.
+
 Take your existing package and add more metadata to it. Install it, then use
 `pip show -v <package>` to see the metadata. You can also look inside the wheel
 or SDist to see the metadata.
@@ -408,6 +410,7 @@ or SDist to see the metadata.
 ::::::::::::::::::::::::::::::::::::: solution
 
 ## Solution
+
 ```bash
 pip install -e .
 pip show -v example-package-YOUR-USERNAME-HERE
@@ -417,11 +420,7 @@ pip show -v example-package-YOUR-USERNAME-HERE
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-
-
-
-
-:::::::::::::::::::::::::::::::::::::: keypoints 
+:::::::::::::::::::::::::::::::::::::: keypoints
 
 - Add informational metadata to tell people about your package.
 - Add functional metadata to tell people how to install and use your package.

--- a/episodes/other-files.md
+++ b/episodes/other-files.md
@@ -4,7 +4,7 @@ teaching: 15
 exercises: 0
 ---
 
-:::::::::::::::::::::::::::::::::::::: questions 
+:::::::::::::::::::::::::::::::::::::: questions
 
 - What other files are important parts of your software package?
 
@@ -18,7 +18,6 @@ exercises: 0
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-
 We now have an installed, working Python package that provides some functionality.
 Are we ready to push the code to GitHub (or your preferred code hosting service) for others to use and contribute to?
 🛑 Not quite—we need to add a few more files at minimum to describe our package, and to actually make it open-source software.
@@ -28,7 +27,7 @@ Aside from the name of the package and docstring included with the (single) func
 We also haven't specified the terms and conditions under which the software may be downloaded, used, and/or modified.
 This means that if we posted it online right now, due to copyright laws (in the United States, at least) nobody else would actually be able to use or modify the code, since we haven't given explicit permission to do so.
 
-Lastly, as you continue working on your package, you will likely fix bugs and modify/add/remove functionality. Although these changes will *technically* be present in your Git logs—because you are committing regularly and writing descriptive commit messages, right? 😉—you should also maintain a file that describes these changes in a human-readable way.
+Lastly, as you continue working on your package, you will likely fix bugs and modify/add/remove functionality. Although these changes will _technically_ be present in your Git logs—because you are committing regularly and writing descriptive commit messages, right? 😉—you should also maintain a file that describes these changes in a human-readable way.
 
 ## Creating a README
 
@@ -36,17 +35,19 @@ A README is a plaintext file that sits at the top level of your package (next to
 Modern READMEs are typically written in Markdown, or occasionally reStructuredText (ReST), due to the additional formatting options that services like GitHub nicely render.
 
 A README is a form of software documentation, and should contain at minimum:
- - the name of your software package
- - a brief description of what your software does or provides
- - installation instructions
- - a brief usage example
- - the type of software license (with more information in a separate `LICENSE` file, described next)
+
+- the name of your software package
+- a brief description of what your software does or provides
+- installation instructions
+- a brief usage example
+- the type of software license (with more information in a separate `LICENSE` file, described next)
 
 In addition, a README may also contain:
- - badges near the top that quickly show key information, such as the latest version, whether the tests are currently passing
- - information about how people can contribute to your package
- - a [code of conduct](https://www.contributor-covenant.org) for people interacting around your project (in GitHub Issues or Pull Requests, for example)
- - contact information for authors and/or maintainers
+
+- badges near the top that quickly show key information, such as the latest version, whether the tests are currently passing
+- information about how people can contribute to your package
+- a [code of conduct](https://www.contributor-covenant.org) for people interacting around your project (in GitHub Issues or Pull Requests, for example)
+- contact information for authors and/or maintainers
 
 Create a README using
 
@@ -80,11 +81,13 @@ rescale(np.linspace(0, 100, 5))
 ```
 
 ## Contributing
+
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
 
 Please make sure to update tests as appropriate.
 
 ## License
+
 TBD
 ````
 
@@ -94,13 +97,12 @@ You can see more guidance on creating READMEs at <https://www.makeareadme.com>.
 
 ## Keep your READMEs relatively brief
 
-You should try to keep your README files *relatively* brief, rather than including
+You should try to keep your README files _relatively_ brief, rather than including
 very detailed documentation to this file. This should only be a high-level introduction,
 with detailed theory, examples, and other information reserved for a true documentation
 website.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
-
 
 ## Choosing a software license
 
@@ -113,21 +115,23 @@ Others cannot use, copy, share/distribute, or modify your work without your perm
 This is often a good thing, because it means you can put your work out into the world, and copyright protects you as the creator and owner of the work.
 Open Source Guides has more about the [legal side of open source software](https://opensource.guide/legal/).
 
-However, if you have created research software and plan to share it openly, you *want* others to use your software, and possibly contribute to it. (Who doesn't love having other people fix the bugs in their code?)
+However, if you have created research software and plan to share it openly, you _want_ others to use your software, and possibly contribute to it. (Who doesn't love having other people fix the bugs in their code?)
 
 A software license provides the explicit permissions for others to use, modify, or share your code, and lays out the specific rules for any restrictions about how they can do those things.
 To pick a license, use resources like [Choose a License](https://choosealicense.com) or [Civic Commons "Choosing a License"](https://wiki.civiccommons.org/Choosing_a_License/) based on how you want others to interact with your software.
 You can also see the [full list of open-source licenses](https://opensource.org/licenses/category) approved by the Open Source Initiative, which maintains the Open Source Definition.
 
 For a new project, you essentially have one major choice to make:
- 1. Do you want to allow others to use your software in almost any way they want, or
- 2. Do you want to require others to share any uses of your project in an open way?
+
+1.  Do you want to allow others to use your software in almost any way they want, or
+2.  Do you want to require others to share any uses of your project in an open way?
 
 These two categories are "permissive" and "copyleft" licenses.
 Common permissive licenses include the [MIT License](https://choosealicense.com/licenses/mit/) and [BSD 3-Clause License](https://choosealicense.com/licenses/bsd-3-clause/).
 The [GNU General Public License v3.0 (or GNU GPLv3) License](https://choosealicense.com/licenses/gpl-3.0/) is a common copyleft license.
 
 Most research software uses permissive licenses like the:
+
 - [BSD 3-Clause License](https://choosealicense.com/licenses/bsd-3-clause/)
   which includes a specific clause preventing the names of creators/contributors
   from being used to endorse or promote derivatives, without permission,
@@ -186,14 +190,12 @@ That's it!
 You should never try to write your own software license, or modify the text of an existing
 license.
 
-Although *we* are not lawyers, the licenses approved and maintained by the Open
+Although _we_ are not lawyers, the licenses approved and maintained by the Open
 Source Initiative have gone through a rigorous review process, including legal review,
 to ensure that they are both consistent with the Open Source Definition and also are
 legally valid.
 
-
 ::::::::::::::::::::::::::::::::::::::::::::::::
-
 
 ::::::::::::::::::::::::::::::::::::: challenge
 
@@ -216,12 +218,12 @@ The Markdown syntax for adding a badge describing the BSD 3-Clause License is:
 ```markdown
 [![License](https://img.shields.io/badge/license-BSD-green.svg)](https://opensource.org/licenses/BSD-3-Clause)
 ```
+
 and will render as [![License](https://img.shields.io/badge/license-BSD-green.svg){alt=''}](https://opensource.org/licenses/BSD-3-Clause)
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
-
 
 ## Keeping a CHANGELOG
 
@@ -245,6 +247,7 @@ rescale.py:11: RuntimeWarning: invalid value encountered in divide
   output_array = (input_array - low) / (high - low)
 array([nan, nan, nan, nan, nan])
 ```
+
 {: .output}
 
 This is probably not the desired output; instead, let's say we want to rescale all the
@@ -297,29 +300,35 @@ to release a new version, you add a new section to the file above this list of c
 Changes should be grouped together based on the type; suggestions for these come from the
 [Keep a Changelog project](https://keepachangelog.com/en/1.0.0/) by
 [Olivier Lacan](https://olivierlacan.com/):
- - `Added` for new features,
- - `Changed` for changes in existing functionality,
- - `Deprecated` for soon-to-be removed features,
- - `Removed` for now-removed features,
- - `Fixed` for any bug fixes, and
- - `Security` in case of vulnerabilities.
+
+- `Added` for new features,
+- `Changed` for changes in existing functionality,
+- `Deprecated` for soon-to-be removed features,
+- `Removed` for now-removed features,
+- `Fixed` for any bug fixes, and
+- `Security` in case of vulnerabilities.
 
 For example, our initial release was version 0.1.0, and we have now changed the functionality.
 Our CHANGELOG should look something like:
 
 ```markdown
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
 ### Changed
+
 - rescale function now scales constant arrays to 1
 
 ## [0.1.0] - 2022-08-09
+
 ### Added
+
 - Created rescale() function and released example_example_package_YOUR_USERNAME_HERE_YOUR_USERNAME_HERE
 ```
 
@@ -330,11 +339,15 @@ to the behavior, you would add a new section for this version:
 ## Unreleased
 
 ## [0.1.1] - 2022-08-10
+
 ### Changed
+
 - rescale function now scales constant arrays to 1
 
 ## [0.1.0] - 2022-08-09
+
 ### Added
+
 - Created rescale() function and released example_example_package_YOUR_USERNAME_HERE_YOUR_USERNAME_HERE
 ```
 
@@ -357,10 +370,10 @@ here for now so that we don't interfere with that lesson.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-
 ::::::::::::::::::::::::::::::::::::: callout
 
 ## Automating Changelog Management
+
 There are several tools which are intended to help manage a changelog.
 Broadly speaking, they use specifically formatted commit messages
 to generate the changelog.
@@ -369,6 +382,7 @@ require consistency and discipline when writing the messages,
 often need manual tweaking of the changelog after generation.
 
 ### `commitizen`, "conventional commits" and SemVer
+
 [`commitizen`][commitizen] is a release management tool which
 helps developers to write [conventional commits][]
 and can generate a grouped and sorted changelog (`commitizen changelog`).
@@ -377,21 +391,22 @@ and generating a changelog
 can be automated using [GitHub Actions][commitizen auto release].
 
 This requires:
+
 - squashing each change into a single commit,
 - consistency and discipline when writing commit messages.
 
 ### GitHub
+
 GitHub can "generate release notes" with each release of code, which is a list of the titles of the **pull requests** included in the release.
 People can view the release notes on GitHub.
 
 These release notes:
+
 - only appear on GitHub,
 - aren't automatically grouped and sorted,
 - only include changes which were part of a pull request title.
 
-
 ::::::::::::::::::::::::::::::::::::::::::::::::
-
 
 [conventional commits]: https://www.conventionalcommits.org/
 [commitizen]: https://commitizen-tools.github.io/commitizen/
@@ -418,6 +433,7 @@ Untracked files:
 
 nothing added to commit but untracked files present (use "git add" to track)
 ```
+
 {: .output}
 
 Fortunately, you can instruct Git to ignore these files, and others that you will never
@@ -637,11 +653,7 @@ The `.git` and `.venv` directories would have been automatically generated
 by Git and Virtualenv respectively. You may also see additional directories
 like `__pycache__` and `.pytest_cache`.
 
-
-
-
-
-:::::::::::::::::::::::::::::::::::::: keypoints 
+:::::::::::::::::::::::::::::::::::::: keypoints
 
 - Packages should include a README, LICENSE, and CHANGELOG.
 - Choose an existing software license

--- a/episodes/publishing.md
+++ b/episodes/publishing.md
@@ -4,7 +4,7 @@ teaching: 10
 exercises: 5
 ---
 
-:::::::::::::::::::::::::::::::::::::: questions 
+:::::::::::::::::::::::::::::::::::::: questions
 
 - How do I publish a package?
 - How do I make my work citable?
@@ -18,11 +18,11 @@ exercises: 5
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-
 If you want other people to be able to access your package,
 you need to publish it.
 
 In this episode we'll:
+
 - investigate the formats you can use to share your package:
   source distribution and wheel,
 - publish those on the Python Package Index (PyPI),
@@ -33,6 +33,7 @@ In this episode we'll:
 ## Formats
 
 One "format" is available as soon as you have pushed your work to a platform like GitHub:
+
 - **repository**:
   - Contains all of your repository, including tests, metadata, and its history,
   - Requires your build backend (hatchling, in this case) to build.
@@ -40,13 +41,14 @@ One "format" is available as soon as you have pushed your work to a platform lik
   - Installation: `pip install git+https://git.example.com/MyProject`
     where `git+` tells `pip` how to interpret the repository.
   - You can also specify particular revisions, like:
-    * `pip install git+https://git.example.com/MyProject.git@v1.0`
-    * `pip install git+https://git.example.com/MyProject.git@main`
-    * `pip install git+https://git.example.com/MyProject.git@da39a3ee5e6b4b0d3255bfef95601890afd80709`
-    * `pip install git+https://git.example.com/MyProject.git@refs/pull/123/head`
+    - `pip install git+https://git.example.com/MyProject.git@v1.0`
+    - `pip install git+https://git.example.com/MyProject.git@main`
+    - `pip install git+https://git.example.com/MyProject.git@da39a3ee5e6b4b0d3255bfef95601890afd80709`
+    - `pip install git+https://git.example.com/MyProject.git@refs/pull/123/head`
 
 If you want to share your work with a wider audience,
 there are two major formats used to publish python packages:
+
 - **source distribution** (`sdist` for short):
   - Contains most of your repository, including tests, and
   - Requires your build backend (hatchling, in this case) to build.
@@ -73,6 +75,7 @@ executable would likely conflict with other things on your system.
 This produces the wheel and sdist in `./dist`.
 
 You can validate the files generated using
+
 ```bash
 pipx run twine check dist/*
 ```
@@ -92,8 +95,6 @@ anaconda.org channel.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-
-
 ## Manual publishing
 
 ::::::::::::::::::::::::::::::::::::: discussion
@@ -106,7 +107,6 @@ your own wheelhouse and point pip at that. Also an "application" like a
 website or other code you deploy probably does not need to be on PyPI.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
-
 
 You can publish files manually with `twine`:
 
@@ -123,7 +123,6 @@ To run this locally, you'll also need to setup an API token to upload the packag
 Create a token at [https://test.pypi.org/manage/account/](https://test.pypi.org/manage/account/).
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
-
 
 However, the best way to publish is from CI. This has
 several benefits: you are always in a clean checkout, so you won't accidentally
@@ -145,7 +144,7 @@ on:
   workflow_dispatch:
   release:
     types:
-    - published
+      - published
 ```
 
 This has two triggers. The first, `workflow_dispatch`, allows you to manually trigger the
@@ -160,16 +159,16 @@ jobs:
   dist:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    - name: Build SDist & wheel
-      run: pipx run build
+      - name: Build SDist & wheel
+        run: pipx run build
 
-    - uses: actions/upload-artifact@v4
-      with:
-        path: dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          path: dist/*
 ```
 
 We've seen the setup before. We are calling the job `dist`, using an Ubuntu
@@ -182,9 +181,11 @@ versioning).
 ## Test and upload action
 
 There's a great action for building and inspecting a pure Python package:
+
 ```yaml
 - uses: hynek/build-and-inspect-python-package@v2
 ```
+
 This action builds, runs various checkers, then uploads the package to `Packages`.
 If you use this, you'll need to download the artifact from `name: Packages`.
 
@@ -202,6 +203,7 @@ We could have combined the build and publish jobs if we really wanted to, but
 they are cleaner when separate, so we have a publish job as well.
 
 {% raw %}
+
 ```yaml
 publish:
   needs: [dist]
@@ -209,14 +211,14 @@ publish:
   if: github.event_name == 'release' && github.event.action == 'published'
 
   steps:
-  - uses: actions/download-artifact@v4
-    with:
-      name: artifact
-      path: dist
+    - uses: actions/download-artifact@v4
+      with:
+        name: artifact
+        path: dist
 
-  - uses: pypa/gh-action-pypi-publish@release/v1
-    with:
-      repository-url: https://test.pypi.org/legacy/
+    - uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
 ```
 
 This job requires that the previous job completes successfully with `needs:`. It
@@ -247,7 +249,7 @@ releases.
 Click Releases -> Draft a new release. Type in or select a tag; the recommended
 format is `v1.2.3`; that is, a "v" followed by a version number. Give it a
 title, like "Version 1.2.3"; keep this short so that it will be readable on the
-web UI.  Finally, fill in the description (there's an autogenerate button that
+web UI. Finally, fill in the description (there's an autogenerate button that
 might be helpful).
 
 When you release, this will trigger the GitHub Action workflow we developed and
@@ -263,6 +265,7 @@ To test the functionality, you can use the [Zenodo Sandbox](https://sandbox.zeno
 ## The CITATION.cff file
 
 From [https://citation-file-format.github.io/](https://citation-file-format.github.io/):
+
 > `CITATION.cff` files are plain text files with human- and machine-readable citation information for software (and datasets).
 > Code developers can include them in their repositories to let others know how to correctly cite their software.
 
@@ -291,13 +294,7 @@ You can validate your file by running:
 pipx run cffconvert --validate
 ```
 
-
-
-
-
-
-
-:::::::::::::::::::::::::::::::::::::: keypoints 
+:::::::::::::::::::::::::::::::::::::: keypoints
 
 - CI can publish Python packages
 - Tagging and GitHub Releases are used to publish versions

--- a/episodes/task-runners.md
+++ b/episodes/task-runners.md
@@ -4,7 +4,7 @@ teaching: 5
 exercises: 5
 ---
 
-:::::::::::::::::::::::::::::::::::::: questions 
+:::::::::::::::::::::::::::::::::::::: questions
 
 - How can you ensure others run the same code you do?
 
@@ -16,12 +16,11 @@ exercises: 5
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-
 A task runner is a tool that lets you specify a set of tasks via a common
 interface.
 
-
 Use of a task runner is optional, but can be helpful to:
+
 - make it easy and simple for new contributors to run things,
 - make specialized developer tasks easy,
 - avoid making single-use virtual environments for docs and other rarely run tasks.
@@ -32,10 +31,12 @@ more flexible, simpler to understand, specialized to one language,
 general to many languages, and so on.
 
 Examples we'll cover include:
+
 - [nox][] (Python semi-general), and
 - [hatch][] (specialized for Python package management).
 
 There are many other task runners for different languages, including:
+
 - [make][] (fully general),
 - [invoke][] (Python general), and
 - [tox][] (Python packages).
@@ -43,11 +44,11 @@ There are many other task runners for different languages, including:
 ::::::::::::::::::::::::::::::::::::: caution
 
 ## Task Runner as Crutch
+
 Task runners can be a crutch, allowing poor packaging practices to be
 employed behind a custom script, and they can hide what is actually happening.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
-
 
 [nox]: https://nox.thea.codes
 [tox]: https://tox.readthedocs.io
@@ -58,8 +59,8 @@ employed behind a custom script, and they can hide what is actually happening.
 
 ::::::::::::::::::::::::::::::::::::: callout
 
-
 ## Further reading
+
 See the [Scientific Python Development Guide page on task runners][scientific-python-task-runners]
 for more information.
 
@@ -109,6 +110,7 @@ Sessions defined in /github/pypa/packaging.python.org/noxfile.py:
 
 sessions marked with * are selected, sessions marked with - are skipped.
 ```
+
 {:.output}
 
 You can see that there are several different sessions. You can run them with `-s`:
@@ -166,7 +168,6 @@ Errors will exit the session.
 
 Let's expand this a little:
 
-
 ```python
 # noxfile.py
 import nox
@@ -185,7 +186,6 @@ This adds a type annotation to the session object, so that IDE's and type
 checkers can help you write the code in the function. There's a docstring,
 which will print out nice help text when a user lists the sessions. And we pass
 through to pytest anything the user passes in via `session.posargs`.
-
 
 Let's try running it:
 
@@ -208,6 +208,7 @@ test_nox.py .                                                                   
 ===================================== 1 passed in 0.05s =====================================
 nox > Session tests was successful.
 ```
+
 {:.output}
 
 You can pass arguments through to the `session.run` command
@@ -228,7 +229,6 @@ def tests(session):
     session.run("pytest")
 ```
 
-
 ::::::::::::::::::::::::::::::::::::: challenge
 
 ## Virtual environments
@@ -240,14 +240,13 @@ How would you activate this environment?
 ::::::::::::::::::::::::::::::::::::: solution
 
 ## Solution
+
 ```bash
 . .nox/tests/bin/activate
 ```
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 ::::::::::::::::::::::::::::::::::::::::::::::::
-
-
 
 ::::::::::::::::::::::::::::::::::::: challenge
 
@@ -258,6 +257,7 @@ Add the commands do preview and build your MkDocs documentation using `nox`.
 ::::::::::::::::::::::::::::::::::::: solution
 
 ## Solution
+
 Add a session to your `noxfile.py` to generate docs:
 
 ```python
@@ -277,14 +277,11 @@ def build_docs(session: nox.Session):
     session.install(".[docs]")
     session.run("mkdocs", "build")
 ```
+
 You now have working docs that you can generate and view cross platform with `nox -s preview_docs`!
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 ::::::::::::::::::::::::::::::::::::::::::::::::
-
-
-
-
 
 ### Backends
 
@@ -295,6 +292,7 @@ which can be useful when you create and destroy virtual environments with `nox`
 many times per day.
 
 - Update the top of your `noxfile.py`:
+
   ```python
   # noxfile.py
 
@@ -303,11 +301,11 @@ many times per day.
   nox.needs_version = ">=2024.3.2"
   nox.options.default_venv_backend = "uv"
   ```
+
 - Install `uv` using your package manager ([installation instructions](https://github.com/astral-sh/uv)).
 
 You can also specify `nox.options.default_venv_backend = "uv|virtualenv"`
 which will fallback to `virtualenv` if `uv` is not installed
-
 
 ::::::::::::::::::::::::::::::::::::: callout
 
@@ -319,10 +317,10 @@ How does the execution time change?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-
 ## Hatch
 
 Hatch is a Python "Project Manager" which can:
+
 - build packages,
 - manage virtual environments,
 - manage multiple python versions for a project,
@@ -335,16 +333,21 @@ Hatch is a Python "Project Manager" which can:
 
 To initialize an existing project for `hatch`,
 enter the directory containing the project and run the following:
+
 ```bash
 hatch new --init
 ```
+
 This will interactively guide you through the setup process.
 
 To run tests using `hatch`, run the following:
+
 ```bash
 hatch test
 ```
+
 This will:
+
 - create a python environment in which your tests will run, then
 - run the tests.
 
@@ -372,16 +375,21 @@ with the `mkdocs-material` and `mkdocstrings` dependencies needed, and
 scripts `serve`, `build` and `deploy` defined within that environment.
 
 Then to view the documentation locally, run `hatch run <ENV>:<SCRIPT>`, e.g.:
+
 ```bash
 hatch run doc:serve
 ```
+
 to run the preview server, or
+
 ```bash
 hatch run doc:build
 ```
+
 to build the documentation, ready for deployment.
 
 The key benefits here are that:
+
 - these scripts run within an isolated environment,
 - the simple commands like `hatch run doc:serve` allow the developer to
   use arguments like `--dev-addr localhost:8000` without needing to remember or think about them.
@@ -390,11 +398,7 @@ The developer must decide whether these benefits outweigh
 the added complexity of an additional layer of abstraction,
 which will hinder debugging if something goes wrong.
 
-
-
-
-
-:::::::::::::::::::::::::::::::::::::: keypoints 
+:::::::::::::::::::::::::::::::::::::: keypoints
 
 - A task runner makes it easier to contribute to software
 

--- a/index.md
+++ b/index.md
@@ -3,15 +3,16 @@ site: sandpaper::sandpaper_site
 ---
 
 What is a package?
-* An organized collection of modules containing functions and classes with a common purpose.
-* Packages allow developers to organize code in manageable and reusable structured units.
+
+- An organized collection of modules containing functions and classes with a common purpose.
+- Packages allow developers to organize code in manageable and reusable structured units.
 
 Why is packaging important in scientific research?
 
-* **Reusability:** Common code can be used across many projects
-* **Collaboration:** Distribute your work with collaborators
-* **Reproducibility:** Allows anyone to run code with the same dependencies to reproduce your results
-* **Portability:** Work in more than one place (e.g. distributed computing)
+- **Reusability:** Common code can be used across many projects
+- **Collaboration:** Distribute your work with collaborators
+- **Reproducibility:** Allows anyone to run code with the same dependencies to reproduce your results
+- **Portability:** Work in more than one place (e.g. distributed computing)
 
 If you have used Python for scientific computation, you've likely encountered widely distributed open-source packages like [NumPy](https://numpy.org/), [SciPy](https://scipy.org/), or [Pandas](https://pandas.pydata.org/). However, it's important to note that packages can exist at many scales and contexts, ranging from personal and organizational use to wide public distributions.
 
@@ -53,7 +54,7 @@ We're going to create a Python package from scratch, then publish it. Packages o
         └── publish.yaml    ─┘
 ```
 
-:::::::::::::::::::::::::::::::::::::: checklist 
+:::::::::::::::::::::::::::::::::::::: checklist
 
 ## See Also
 
@@ -64,10 +65,10 @@ This is a tutorial. For reference material, you should bookmark the following gu
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-:::::::::::::::::::::::::::::::::::::: prereq 
+:::::::::::::::::::::::::::::::::::::: prereq
 
 ## Prerequisites
 
-* Basic Python
+- Basic Python
 
 ::::::::::::::::::::::::::::::::::::::::::::::::

--- a/instructors/instructor-notes.md
+++ b/instructors/instructor-notes.md
@@ -1,10 +1,12 @@
 ---
 title: "Instructor Notes"
 ---
+
 This lesson is a process-oriented tutorial on creating a Python package for Research Software Engineers.
 
-After giving an overview of all the files we're going to touch (on the index page), 
+After giving an overview of all the files we're going to touch (on the index page),
 it follows the process of creating a package:
+
 - Create a new repository (setup),
 - Create a virtual environment,
 - Add some code and tests,
@@ -16,7 +18,7 @@ it follows the process of creating a package:
 - Publish the package and make it citeable by adding an additional metadata file.
 
 The lesson is intentionally more challenging than an entry-level how-to guide on packaging.
-At each step when a new concept is introduced, 
+At each step when a new concept is introduced,
 it dives deeper into the detail than a how-to guide would –
-for instance, we only get to code after setting up an environment 
+for instance, we only get to code after setting up an environment
 and initializing the infrastructure needed for reproducible builds.

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -2,16 +2,18 @@
 title: Setup
 ---
 
-
 ::::::::::::::::::::::::::::::::::::: objectives
 
 ## Objectives
+
 You will need accounts on:
+
 - [https://github.com/](https://github.com/)
 - [https://test.pypi.org/](https://test.pypi.org/)
 - [https://zenodo.org/](https://zenodo.org/)
 
 These instructions serve to help set up:
+
 - an editor,
 - a shell,
 - python,
@@ -20,10 +22,7 @@ These instructions serve to help set up:
 
 either in the cloud (fast) or on a local computer (slow the first time).
 
-
 ::::::::::::::::::::::::::::::::::::::::::::::::
-
-
 
 ## User Accounts
 
@@ -33,21 +32,19 @@ If you don't already have them, sign up for accounts on:
 - [https://test.pypi.org/account/register/](https://test.pypi.org/account/register/) (required for the part on publishing)
 - [https://zenodo.org/signup/](https://zenodo.org/signup/) (optional for the part on citation)
 
-
 ## Development Environment
 
 ::::::::::::::::::::::::::::::::::::: caution
 
 ## If this is your first time, use the `Cloud` instructions
+
 If you have not installed and used these tools before, then in the interests of time for the lesson, please use the **Cloud** setup instructions. After the session you can repeat the setup using the Local setup instructions.
 
 Support will be available for the rest of the week if you have trouble with setting up these tools locally!
 
-
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-
-### Cloud
+### A. Cloud
 
 You can get all the prerequisites for this lesson by using a GitHub Codespace.
 
@@ -57,22 +54,23 @@ You can get all the prerequisites for this lesson by using a GitHub Codespace.
   - Initialize the repository with a README file by clicking the tickmark next to `Add a README file`.
 - After the repository is created, click on the `< > Code` button, click the `Codespaces` tab, and click `Create codespace on main`. This will create an editor with a shell, `python` and `git` pre-configured for you.
 
-### Local
+### B. Local
 
 If you want to run this example on your own computer, you will need to install the parts independently.
 
-#### Editor
+#### i. Editor
 
 We recommend using the text editor VSCode from [https://code.visualstudio.com/](https://code.visualstudio.com/) for this lesson. We won't be using any of its special features, so if you prefer a different editor, please use that.
 
-#### Shell
+#### ii. Shell
 
 This lesson uses shell commands which you can run in a terminal emulator. Depending on the operating system you use, you have different options.
+
 - Linux – you can use any terminal emulator. Common options are `GNOME Terminal` and `Konsole (KDE)`.
 - macOS – you can use any terminal emulator. Common options are: `Terminal.app`, `iTerm2`
 - Windows – we recommend using the Windows Subsystem for Linux to install Linux (https://learn.microsoft.com/en-us/windows/wsl/install). You could also use Powershell, but some commands will be different and others unavailable.
 
-#### Python
+#### iii. Python
 
 You will need to have Python installed for this lesson.
 
@@ -82,21 +80,19 @@ To check if python is available in your shell, call `python3 --version`. You sho
 % python3 --version
 Python 3.12.3
 ```
-{:code}
 
 If this command returns something like `command not found: python3` then you can install python using
 the instructions on [https://wiki.python.org/moin/BeginnersGuide/Download](https://wiki.python.org/moin/BeginnersGuide/Download).
 
 Often, developers will need to manage multiple projects which might all use several different python versions.
-This is sometimes tricky, and there are specialized tools which can help, like:
+This is sometimes tricky, and there are specialized tools which can help:
 
-- [`asdf`](https://asdf-vm.com/),
-- [`hatch`](https://hatch.pypa.io/latest/),
-- [`mise`](https://mise.jdx.dev/lang/python),
-- [`pdm`](https://rye.astral.sh/),
-- [`pyenv`](https://github.com/pyenv/pyenv), or
-- [`rye`](https://rye.astral.sh/).
-
+- [`asdf`](https://asdf-vm.com/)
+- [`hatch`](https://hatch.pypa.io/latest/)
+- [`mise`](https://mise.jdx.dev/lang/python)
+- [`pdm`](https://rye.astral.sh/)
+- [`pyenv`](https://github.com/pyenv/pyenv)
+- [`rye`](https://rye.astral.sh/)
 
 #### Git & GitHub
 
@@ -109,6 +105,7 @@ For beginners, we recommend using GitHub desktop when working with GitHub – in
 #### Empty repository
 
 Create a new repository using GitHub desktop.
+
 - Open GitHub Desktop
 - Select File > New Repository
 - Specify the repository data:


### PR DESCRIPTION
Some bulleted lists were not converted properly when converted to the new carpentries format. They needed a blank line of padding to be rendered as a separate list from the preceding paragraph. This PR adds those lines and other formatting picked up by the linter. 