### PR TITLE
fix: skip URL checks on initial push with zero base commit

### DIFF
--- a/.github/workflows/check-pr-urls.yml
+++ b/.github/workflows/check-pr-urls.yml
@@ -30,6 +30,7 @@ jobs:
       # We maintain the list of the URLs excluded from checking in a separate file so that we can use
       # it in multiple workflows, while easily maintaining consistency.
       - name: Read exclude-urls list
+        if: steps.check_base.outputs.skip == 'false'
         id: exclude
         uses: juliangruber/read-file-action@v1
         with:

--- a/.github/workflows/check-pr-urls.yml
+++ b/.github/workflows/check-pr-urls.yml
@@ -9,10 +9,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
+
+      # On initial push, the `before` SHA is all zeros, so we skip the changed file check
+      # It will run on subsequent pushes to the same PR and on the PR check.
+      - name: Check if base commit is zero
+        id: check_base
+        run: |
+          if [[ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
 
       - id: files
+        if: steps.check_base.outputs.skip == 'false'
         uses: masesgroup/retrieve-changed-files@v3
         with:
           format: "csv"
@@ -27,6 +37,7 @@ jobs:
 
       # Run URL checks
       - name: URLs-checker
+        if: steps.check_base.outputs.skip == 'false'
         uses: urlstechie/urlchecker-action@0.0.34
         with:
           # only include the changed files


### PR DESCRIPTION
#116 Didn't fix the problem with the initial push failing. This update adds conditional to check if the base branch is non-existent (This only happens when pushing a new branch to the remote) and skips the URL check action. Subsequent updates to the branch and the pull requests will run the check. 